### PR TITLE
Consolidate config vars into local vars while preserving formatting

### DIFF
--- a/roles/cmdsrv/files/iiab-cmdsrv
+++ b/roles/cmdsrv/files/iiab-cmdsrv
@@ -1881,7 +1881,7 @@ def write_config_vars():
         fd.write(outstr)
         fd.close()
     finally:
-        lock.release()
+        lock.release() # release lock, no matter what
 
 def read_iiab_vars():
     global default_vars

--- a/roles/cmdsrv/files/iiab-cmdsrv
+++ b/roles/cmdsrv/files/iiab-cmdsrv
@@ -1029,9 +1029,14 @@ def get_oer2go_catalog(cmd_info):
         return ('{"Error": "' + outp + '."}')
 
 def get_config_vars(cmd_info):
+    global local_vars_error
     read_config_vars()
-    resp = json.dumps(config_vars)
-    return (resp)
+    if len(local_vars_error) > 0:
+        resp = cmd_error(cmd='GET-CONF', msg=local_vars_error)
+        return (resp)
+    else:
+        resp = json.dumps(config_vars)
+        return (resp)
 
 def set_config_vars(cmd_info):
     global config_vars
@@ -1774,9 +1779,15 @@ def init():
 
 def read_config_vars():
     global config_vars
-
-    stream = open(config_vars_file, 'r')
-    config_vars = yaml.load(stream)
+    global local_vars_error
+    try:
+        stream = open(local_vars_file, 'r')
+        config_vars = yaml.load(stream)
+        local_vars_error = ''
+    except Exception as e:
+        if hasattr(e, 'problem_mark'):
+            mark = e.problem_mark
+            local_vars_error = "Syntax Error in " + local_vars_file + " on line %s"%str(mark.line+1)
     stream.close()
     if config_vars == None:
         config_vars = {} # try to make the ajax call happy
@@ -1801,32 +1812,88 @@ def write_config_vars():
     global config_vars
 
     lock.acquire() # will block if lock is already held
+    local_vars_lines = []
+    found_vars = []
+    separator_found = False
 
     try:
-        stream =  open(config_vars_file, 'w')
-        stream.write('# DO NOT MODIFY THIS FILE.\n')
-        stream.write('# IT IS AUTOMATICALLY GENERATED.\n')
-        for key in config_vars:
-             if isinstance(config_vars[key], (int, float)): # boolean is int
-                 value = str(config_vars[key])
-             else:
-                 value = '"' + config_vars[key] + '"'
-             entry = key + ': ' + value
-             stream.write(entry + '\n')
-        stream.close()
+        fd = open(local_vars_file, 'r')
+        local_vars_lines = fd.readlines()
+        fd.close()
+
+        # accumulate new local_vars.yml into outstr
+        outstr = ""
+        for line in local_vars_lines:
+            # copy blank lines
+            if line.strip() == "":
+                outstr += line
+                continue
+
+            # if commented out, check for disagreement in value
+            hash = line.find("#")
+            if hash == 0:
+                m = re.match('# *([a-zA-Z0-9_]*) *: *([a-zA-Z0-9\'\"\.]*) *(#.*)*',line)
+                if m:
+                    if m.group(1) in config_vars:
+                        if m.group(1) not in default_vars or config_vars[m.group(1)] != default_vars[m.group(1)]:
+                            vardec = m.group(1) + ": " + str(config_vars[m.group(1)]) + "  \n"
+                            if m.group(3):
+                                vardec =  vardec.strip() + "   " + m.group(3) + "\n"
+                            outstr += vardec
+                        found_vars.append(m.group(1))
+                else:
+                    outstr += line
+                if line.startswith("# IIAB"):
+                    separator_found = True
+                continue
+           
+            # change value if there is disagreement, trailing comments are unchanged
+            m = re.match(' *([a-zA-Z0-9_]*) *: *([a-zA-Z0-9\'\"\.]*) *(#.*)*',line)
+            if m and m.group(1) in config_vars:
+                if config_vars[m.group(1)] != m.group(2):
+                    if isinstance(config_vars[m.group(1)], unicode) and config_vars[m.group(1)].find(" ") != -1:
+                        vardec = m.group(1) + ": \"" + str(config_vars[m.group(1)]) + "\"\n"
+                    else:
+                        vardec = m.group(1) + ": " + str(config_vars[m.group(1)]) + "\n"
+                        if m.group(3):
+                            vardec = vardec.strip() + "   " + m.group(3) + "\n"
+                    outstr += vardec
+                else:
+                    outstr += line
+                found_vars.append(m.group(1))
+            else:
+                print("no match for: %s"%line)
+                outstr += line
+
+        # put any variables not already found in local_vars.yml
+        if not separator_found:
+            outstr +="\n\n############################################################################\n" 
+            outstr +="# IIAB -- following variables are first set by browser via the Admin Console\n"
+            outstr +="#  They may be changed via text editor, or by the Admin Console.\n\n"
+        for variable_name in config_vars:
+            if variable_name not in found_vars:
+                if str(config_vars[variable_name]).find(" ") == -1:
+                    outstr += variable_name + ": " + str(config_vars[variable_name]) + "\n"
+                else:
+                    outstr += variable_name + ": \"" + str(config_vars[variable_name]) + "\"\n"
+
+        fd = open(local_vars_file,"w")
+        fd.write(outstr)
+        fd.close()
     finally:
-        lock.release() # release lock, no matter what
+        lock.release()
 
 def read_iiab_vars():
     global default_vars
     global local_vars
     global effective_vars
+    global local_vars_error
 
     stream = open(iiab_repo + "/vars/default_vars.yml", 'r')
     default_vars = yaml.load(stream)
     stream.close()
 
-    stream = open(iiab_repo + "/vars/local_vars.yml", 'r')
+    stream = open(local_vars_file, 'r')
     local_vars = yaml.load(stream)
     stream.close()
 
@@ -2031,7 +2098,7 @@ def app_config():
     global iiab_config_dir
     global iiab_config_file
     global iiab_ini_file
-    global config_vars_file
+    global local_vars_file
     global cmdsrv_dbpath
     global cmdsrv_dbname
     global cmdsrv_no_workers
@@ -2070,7 +2137,7 @@ def app_config():
     iiab_config_dir = conf['iiab_config_dir']
     iiab_config_file = conf['iiab_config_file']
     iiab_ini_file = conf['iiab_ini_file']
-    config_vars_file = iiab_config_dir + "/config_vars.yml"
+    local_vars_file = iiab_config_dir + "/local_vars.yml"
 
     cmdsrv_dbname = conf['cmdsrv_dbname']
     cmdsrv_dbpath = cmdsrv_dir + "/" + cmdsrv_dbname


### PR DESCRIPTION
- Moved local_vars.yml to `/etc/iiab`
- Merged {config_vars} values into local_vars.yml
- Vars missing in local_vars.yml are appended to end with message indicating source
- local_vars uncommented, and set, if config_vars disagrees with default_vars
- Trailing comments in local_vars.yml preserved
- Order of local_vars.yml preserved
- Comments and blank lines preserved
- Added feedback on line number where error occurs in local_vars.yml in first init list on admin console (because yaml parse failure breaks admin console, and is now more likely)
- Tested such that all the GUI checkboxes, values appear to be preserved (on rpi3, raspbian)
- Not worth final integration testing, and cross platform exploration until Tim approves basic design.