### PR TITLE
install zims fails to execute

### DIFF
--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -1981,7 +1981,7 @@ function sendCmdSrvCmd(command, callback, buttonId, errCallback, cmdArgs) {
 
   logServerCommands (cmdVerb, "sent");
 
-  if (buttonId === undefined)
+  if (buttonId === undefined || buttonId === '')
   buttonId = "";
   else
     make_button_disabled('#' + buttonId, true);


### PR DESCRIPTION
zim_functions.js line 13: passes a null string as buttonId. 
    sendCmdSrvCmd(cmd, genericCmdHandler, "", instZimError, cmd_args); but
admin-console.js line 1984 only checks for undefined: -- and fails to find $(#<null string>)
  line 1984 = "if (buttonId === undefined)"
--This checks for both
