### PR TITLE
buttonId='' on new master

### DIFF
--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -1949,7 +1949,7 @@ function formCommand(cmd_verb, args_name, args_obj)
 
 // monitor for awhile and use version if no problems present
 
-function sendCmdSrvCmd(command, callback, buttonId, errCallback, cmdArgs) {
+function sendCmdSrvCmd(command, callback, buttonId = '', errCallback, cmdArgs) {
   // takes following arguments:
   //   command - Command to send to cmdsrv
   //   callback - Function to call on success
@@ -1981,9 +1981,7 @@ function sendCmdSrvCmd(command, callback, buttonId, errCallback, cmdArgs) {
 
   logServerCommands (cmdVerb, "sent");
 
-  if (buttonId === undefined)
-  buttonId = "";
-  else
+  if (buttonId != '')
     make_button_disabled('#' + buttonId, true);
 
     var resp = $.ajax({


### PR DESCRIPTION
installed on top of an iiab-admin-console with lots of development work (using ./install in repo root). Tested by installing a new zim   via console.