### PR TITLE
windows 7 still uses javascript version ES5

### DIFF
--- a/roles/js-menu/files/menu-files/js/js-menu.js
+++ b/roles/js-menu/files/menu-files/js/js-menu.js
@@ -122,8 +122,8 @@ var getLangCodes = $.getJSON(consoleJsonDir + 'lang_codes.json')
 $.when(getMenuJson, getZimVersions, getConfigJson, getLangCodes).always(procMenu);
 
 // This is the main processing
-function jsMenuMain (menuDiv = "content") {
-	menuDivId = menuDiv;
+function jsMenuMain (menuDiv) {
+	menuDivId = menuDiv || "content";
   genRegEx(); // regular expressions for subtitution
   if (dynamicHtml){
   	getLocalStore();


### PR DESCRIPTION
internet explorer 11, with an about date of 2013, gets a javascript error in js-menu.js, and jsMenuMain is undefined, in home/index.html.
