### PR TITLE
New menu defs for fr-hesperian (as opposed to fr-hesperian_health)

### DIFF
--- a/roles/js-menu/files/menu-files/menu-defs/fr-hesperian.html
+++ b/roles/js-menu/files/menu-files/menu-defs/fr-hesperian.html
@@ -1,0 +1,7 @@
+<ul class="double">
+
+  <li><a href="/modules/fr-hesperian/werner-david-la-ou-il-n-y-a-pas-de-docteur.pdf">L&agrave; o&ugrave; il n'y a pas de Docteur</a></li>
+
+  <li><a href="/modules/fr-hesperian/la-ou-il-n-y-a-pas-dentiste-traduction-fr.pdf">L&agrave; ou il y a pas de Dentiste</a></li>
+
+</ul>

--- a/roles/js-menu/files/menu-files/menu-defs/fr-hesperian.json
+++ b/roles/js-menu/files/menu-files/menu-defs/fr-hesperian.json
@@ -1,0 +1,9 @@
+{
+    "intended_use": "html",
+    "lang": "fr",
+    "logo_url": "hesperianlogo.png",
+    "moddir" : "fr-hesperian",
+    "title" : "Hesperian Guides de Sant&eacute; en Fran&ccedil;ais",
+    "description": "Des guides faciles &agrave; comprendre, pratiques, pr&eacute;cis et fortement illustr&eacute;s sur les th&egrave;mes de sant&eacute; que dans les r&eacute;gions &eacute;loign&eacute;es o&ugrave; l'acc&egrave;s au personnel m&eacute;dical et les installations sont limit&eacute;es.",
+    "extra_html": "fr-hesperian.html"
+}


### PR DESCRIPTION
Looks like the module directory/name has changed to fr-hesperian.  I left the old menu defs in just in case.