### PR TITLE
Update en-map_test.json per #1776

### DIFF
--- a/roles/js-menu/files/menu-files/menu-defs/en-map_test.json
+++ b/roles/js-menu/files/menu-files/menu-defs/en-map_test.json
@@ -6,6 +6,5 @@
   "map_name": "en-map_test",
   "logo_url": "osm.jpg",
   "description": "To install a Map Pack for a continent or the entire world, use the Admin Console (http://box.lan/admin, default password at http://FAQ.IIAB.IO) > <b>Install Content</b> > <b>Add Map Region</b>",
-  "extra_description": "Complete instructions are here: <a href=https://github.com/iiab/iiab/wiki/IIAB-Maps>https://github.com/iiab/iiab/wiki/IIAB-Maps</a>",
-  "extra_html": "This page is installed by default during the initial installation of Internet-in-a-Box."
+  "extra_description": "Complete instructions are here: <a href=https://github.com/iiab/iiab/wiki/IIAB-Maps>https://github.com/iiab/iiab/wiki/IIAB-Maps</a><p>(This stub is installed by default during the initial installation of Internet-in-a-Box.  Remove this stub using http://box.lan/admin > <b>Manage Content</b> > <b>Content Item List</b>)"
 }

--- a/roles/js-menu/files/menu-files/menu-defs/en-map_test.json
+++ b/roles/js-menu/files/menu-files/menu-defs/en-map_test.json
@@ -1,10 +1,10 @@
 {
-  "lang": "en",
-  "intended_use": "map",
-  "title": "OpenStreetMap Test Page",
-  "start_url": "maplist",
-  "map_name": "en-map_test",
-  "logo_url": "osm.jpg",
-  "description": "To install a Map Pack for a continent or the entire world, use <a href=http://box.lan/admin>Admin Console</a> (see <a href='/info/FAQ.html#What_are_the_default_passwords.3F'>default passwords</a>) > <b>Install Content</b> > <b>Add Map Region</b>.",
-  "extra_description": "See also the <a href='https://github.com/iiab/iiab/wiki/IIAB-Maps'>full instructions</a> for IIAB Maps.<p>(This stub is installed by default during the initial installation of Internet-in-a-Box.  Remove this stub using <a href=http://box.lan/admin>Admin Console</a> > <b>Manage Content</b> > <b>Content Item List</b>)"
+    "lang": "en",
+    "intended_use": "map",
+    "title": "OpenStreetMap Test Page",
+    "start_url": "maplist",
+    "map_name": "en-map_test",
+    "logo_url": "osm.jpg",
+    "description": "To install a Map Pack for a continent or the entire world, use <a href=http://box.lan/admin>Admin Console</a> (see <a href='/info/FAQ.html#What_are_the_default_passwords.3F'>default passwords</a>) > <b>Install Content</b> > <b>Add Map Region</b>.",
+    "extra_description": "You can remove this stub from your IIAB home page using <a href=http://box.lan/admin>Admin Console</a> > <b>Manage Content</b> > <b>Content Item List</b>.<p>See also the <a href='https://github.com/iiab/iiab/wiki/IIAB-Maps'>full instructions</a> for IIAB Maps."
 }

--- a/roles/js-menu/files/menu-files/menu-defs/en-map_test.json
+++ b/roles/js-menu/files/menu-files/menu-defs/en-map_test.json
@@ -2,10 +2,10 @@
   "lang": "en",
   "intended_use": "map",
   "title": "OpenStreetMap Test Page",
-  "extra_html": "",
   "start_url": "maplist",
-  "menu_item_name": "en-map_test.json",
   "map_name": "en-map_test",
   "logo_url": "osm.jpg",
-  "description": "<p>This page is installed by default during the initial installation of Internet In A Box>"
+  "description": "To install a Map Pack for a continent or the entire world, use the Admin Console (http://box.lan/admin, default password at http://FAQ.IIAB.IO) > <b>Install Content</b> > <b>Add Map Region</b>",
+  "extra_description": "Complete instructions are here: <a href=https://github.com/iiab/iiab/wiki/IIAB-Maps>https://github.com/iiab/iiab/wiki/IIAB-Maps</a>",
+  "extra_html": "This page is installed by default during the initial installation of Internet-in-a-Box."
 }

--- a/roles/js-menu/files/menu-files/menu-defs/en-map_test.json
+++ b/roles/js-menu/files/menu-files/menu-defs/en-map_test.json
@@ -5,6 +5,6 @@
   "start_url": "maplist",
   "map_name": "en-map_test",
   "logo_url": "osm.jpg",
-  "description": "To install a Map Pack for a continent or the entire world, use the Admin Console (http://box.lan/admin, default password at http://FAQ.IIAB.IO) > <b>Install Content</b> > <b>Add Map Region</b>",
-  "extra_description": "Complete instructions are here: <a href=https://github.com/iiab/iiab/wiki/IIAB-Maps>https://github.com/iiab/iiab/wiki/IIAB-Maps</a><p>(This stub is installed by default during the initial installation of Internet-in-a-Box.  Remove this stub using http://box.lan/admin > <b>Manage Content</b> > <b>Content Item List</b>)"
+  "description": "To install a Map Pack for a continent or the entire world, use <a href=http://box.lan/admin>Admin Console</a> (see <a href='/info/FAQ.html#What_are_the_default_passwords.3F'>default passwords</a>) > <b>Install Content</b> > <b>Add Map Region</b>.",
+  "extra_description": "See also the <a href='https://github.com/iiab/iiab/wiki/IIAB-Maps'>full instructions</a> for IIAB Maps.<p>(This stub is installed by default during the initial installation of Internet-in-a-Box.  Remove this stub using <a href=http://box.lan/admin>Admin Console</a> > <b>Manage Content</b> > <b>Content Item List</b>)"
 }


### PR DESCRIPTION
See https://github.com/iiab/iiab/pull/1776

FYI @tim-moody is working on a related issue (https://github.com/iiab/iiab-admin-console/pull/226 for https://github.com/iiab/iiab/issues/1723) that appears to be having a side-effect of causing "description" with "extra_description" to be appear mashed together w/o a line break or paragraph break?

And a related issue where "extra_html" isn't showing up at all?

(So fully testing this PR may be easier after the above small issues are solved.)