### PR TITLE
remove confusing alert [OSM]

### DIFF
--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -306,7 +306,7 @@ function instContentButtonsEvents() {
              }
              if (skip_map || mapWip.indexOf(map_id) != -1){
                consoleLog("Skipping installed Module " + map_id);
-               alert ("Selected Map Region is already installed.\n");
+               //alert ("Selected Map Region is already installed.\n");
 
              } else {
                instMapItem(map_id);


### PR DESCRIPTION
Tested on buster in VM. This ignores regions already installed,(and does not issue a confusing message when one of the buttons that is checked is already installed). 

But it will install a newly released version of a map.