### PR TITLE
Clean metadata for teachers, in 'footnotes' on http://box

### DIFF
--- a/roles/cmdsrv/templates/scripts/iiab_update_menus.py
+++ b/roles/cmdsrv/templates/scripts/iiab_update_menus.py
@@ -186,7 +186,7 @@ def create_menu_def(perma_ref,default_name,intended_use='zim'):
    menuDef["description"] = item.get('description','')
    menuDef["extra_description"] = ""
    menuDef["extra_html"] = ""
-   menuDef["footnote"] = 'Size: ##SIZE##, Articles: ##ARTICLE_COUNT##, Media: ##MEDIA_COUNT##, Tags; [##tags##], Language: ##language##, Date: ##zim_date##'
+   menuDef["footnote"] = 'Size: ##SIZE##, Articles: ##ARTICLE_COUNT##, Media: ##MEDIA_COUNT##, Date: ##zim_date##'
 
    menuDef["change_ref"] = "generated"
    menuDef['change_date'] = str(date.today())


### PR DESCRIPTION
Modify [iiab_update_menus.py](https://github.com/iiab/iiab-admin-console/blob/master/roles/cmdsrv/templates/scripts/iiab_update_menus.py) so that it stops producing excessive/redundant/broken metadata, that educators really don't want to see.

For librarians that cannot find these tags & the language in other ways, this information is generally already included within Content Pack URL's.