### PR TITLE
/library/www/html/js-menu/menu-files/images/* should not be executable

### DIFF
--- a/roles/js-menu/tasks/main.yml
+++ b/roles/js-menu/tasks/main.yml
@@ -59,7 +59,7 @@
 
 - name: Make web server user owner of images after copying
   file: path="{{ js_menu_dir }}menu-files/images/"
-        mode=0755
+        mode=u+rw,go+r
         owner="{{ apache_user }}"
         group="{{ apache_user }}"
         state=directory


### PR DESCRIPTION
Line 62 could probably be removed entirely, but `mode=u+rw,go+r` is safer.