### PR TITLE
IE 11 does not have string.includes()

### DIFF
--- a/roles/js-menu/files/menu-files/js/js-menu.js
+++ b/roles/js-menu/files/menu-files/js/js-menu.js
@@ -228,7 +228,7 @@ function procStatic(){
 }
 
 function procMenu() {
-	if (isMobile || navigator.userAgent.includes('Win64') || navigator.platform == 'MacIntel') {
+	if (isMobile || navigator.userAgent.search('Win64') !== -1 || navigator.platform == 'MacIntel') {
     	var allowed = menuConfig.apache_allow_sudo || false;
     	var desired = menuParams.allow_server_time_update || false;
   	  if (allowed && desired)


### PR DESCRIPTION
https://www.w3schools.com/jsref/jsref_includes.asp
smoke tested and functions in IE 11

This is necessary but not sufficient for captive portal on Windows 7