### PR TITLE
change how raspberry pi is determined

### DIFF
--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -1256,7 +1256,7 @@ def set_wpa_credentials (cmd_info):
     return resp
 
 def ctl_bluetooth(cmd_info):
-    if ansible_facts['ansible_local']['local_facts']['os'] != 'raspbian':
+    if ansible_facts['ansible_local']['local_facts']['rpi_model'] != 'none':
         resp = cmd_error(cmd=cmd_info['cmd'], msg='Only supported on Raspberry Pi.')
         return (resp)
 


### PR DESCRIPTION
Bluetooth on/off toggle doesn't recognise that a Raspberry Pi running Ubuntu is an RPi. It is just checking for Raspbian. This change checks to see if ansible fact "rpi_model" is not equal to 'none'. 