### PR TITLE
iiab/iiab#2985 interim fix for Admin Console logins across new distros ⁠— regardless whether /etc/shadow uses SHA-512, yescrypt or other hashing schemes

### DIFF
--- a/roles/console/templates/cmd-service3.wsgi.j2
+++ b/roles/console/templates/cmd-service3.wsgi.j2
@@ -177,8 +177,8 @@ def auth_login(credentials64, client_public_key64, nonce64): # candidate for adm
     # if calcpasswd != readpasswd:
     
     # 2021-09-26: Works with all hashes in /etc/shadow (SHA-512, yescrypt, etc) for #2985
-    hashpasswd = subprocess.run(['perl', '-e', f"print crypt('{password}', '{readpasswd}')"], capture_output=True, text=True).stdout
-    if hashpasswd != readpasswd:
+    calcpasswd = subprocess.run(['perl', '-e', f"print crypt('{password}', '{readpasswd}')"], capture_output=True, text=True).stdout
+    if calcpasswd != readpasswd:
         print('Bad Password')
         return False
     else:

--- a/roles/console/templates/cmd-service3.wsgi.j2
+++ b/roles/console/templates/cmd-service3.wsgi.j2
@@ -165,7 +165,7 @@ def auth_login(credentials64, client_public_key64, nonce64): # candidate for adm
         return False
 
     # check password - N.B. allows password guessing
-    # readpasswd = spwddb[1]
+    readpasswd = spwddb[1]
     # pwparts = readpasswd.split('$')
     # if len(pwparts) < 4:
     #     salt = ''
@@ -177,7 +177,8 @@ def auth_login(credentials64, client_public_key64, nonce64): # candidate for adm
     # if calcpasswd != readpasswd:
     
     # 2021-09-26: Works with all hashes in /etc/shadow (SHA-512, yescrypt, etc) for #2985
-    if subprocess.run(['perl', '-e', f"print crypt('{password}', '{spwddb[1]}')"], capture_output=True, text=True).stdout != spwddb[1]:
+    hashpasswd = subprocess.run(['perl', '-e', f"print crypt('{password}', '{readpasswd}')"], capture_output=True, text=True).stdout
+    if hashpasswd != readpasswd:
         print('Bad Password')
         return False
     else:

--- a/roles/console/templates/cmd-service3.wsgi.j2
+++ b/roles/console/templates/cmd-service3.wsgi.j2
@@ -165,7 +165,7 @@ def auth_login(credentials64, client_public_key64, nonce64): # candidate for adm
         return False
 
     # check password - N.B. allows password guessing
-    readpasswd = spwddb[1]
+    # readpasswd = spwddb[1]
     # pwparts = readpasswd.split('$')
     # if len(pwparts) < 4:
     #     salt = ''
@@ -177,8 +177,9 @@ def auth_login(credentials64, client_public_key64, nonce64): # candidate for adm
     # if calcpasswd != readpasswd:
     
     # 2021-09-26: Works with all hashes in /etc/shadow (SHA-512, yescrypt, etc) for #2985
-    calcpasswd = subprocess.run(['perl', '-e', f"print crypt('{password}', '{readpasswd}')"], capture_output=True, text=True).stdout
-    if calcpasswd != readpasswd:
+    readhashstr = spwddb[1]
+    calchashstr = subprocess.run(['perl', '-e', f"print crypt('{password}', '{readhashstr}')"], capture_output=True, text=True).stdout
+    if calchashstr != readhashstr:
         print('Bad Password')
         return False
     else:

--- a/roles/console/templates/cmd-service3.wsgi.j2
+++ b/roles/console/templates/cmd-service3.wsgi.j2
@@ -177,12 +177,12 @@ def auth_login(credentials64, client_public_key64, nonce64): # candidate for adm
     # if calcpasswd != readpasswd:
     
     # 2021-09-26: Works with all hashes in /etc/shadow (SHA-512, yescrypt, etc) for #2985
-    readhashstr = spwddb[1]
+    read_pw_hash = spwddb[1]
     try:
-        calchashstr = subprocess.run(['perl', '-e', f"print crypt('{password}', '{readhashstr}')"], capture_output=True, text=True).stdout
+        calc_pw_hash = subprocess.run(['perl', '-e', f"print crypt('{password}', '{read_pw_hash}')"], capture_output=True, text=True).stdout
     except:
-        calchashstr = None
-    if calchashstr != readhashstr:
+        calc_pw_hash = None
+    if calc_pw_hash != read_pw_hash:
         print('Bad Password')
         return False
     else:

--- a/roles/console/templates/cmd-service3.wsgi.j2
+++ b/roles/console/templates/cmd-service3.wsgi.j2
@@ -178,7 +178,10 @@ def auth_login(credentials64, client_public_key64, nonce64): # candidate for adm
     
     # 2021-09-26: Works with all hashes in /etc/shadow (SHA-512, yescrypt, etc) for #2985
     readhashstr = spwddb[1]
-    calchashstr = subprocess.run(['perl', '-e', f"print crypt('{password}', '{readhashstr}')"], capture_output=True, text=True).stdout
+    try:
+        calchashstr = subprocess.run(['perl', '-e', f"print crypt('{password}', '{readhashstr}')"], capture_output=True, text=True).stdout
+    except:
+        calchashstr = None
     if calchashstr != readhashstr:
         print('Bad Password')
         return False

--- a/roles/console/templates/cmd-service3.wsgi.j2
+++ b/roles/console/templates/cmd-service3.wsgi.j2
@@ -7,6 +7,7 @@ import pwd
 import spwd
 import grp
 import secrets
+import subprocess
 import base64
 import nacl.utils
 from nacl.public import PrivateKey, PublicKey, Box
@@ -164,16 +165,19 @@ def auth_login(credentials64, client_public_key64, nonce64): # candidate for adm
         return False
 
     # check password - N.B. allows password guessing
-    readpasswd = spwddb[1]
-    pwparts = readpasswd.split('$')
-    if len(pwparts) < 4:
-        salt = ''
-        print('No Password Salt')
-    else:
-        salt = '$' + pwparts[1] + '$' +  pwparts[2] +'$'
-    calcpasswd = crypt.crypt(password, salt)
-
-    if calcpasswd != readpasswd:
+    # readpasswd = spwddb[1]
+    # pwparts = readpasswd.split('$')
+    # if len(pwparts) < 4:
+    #     salt = ''
+    #     print('No Password Salt')
+    # else:
+    #     salt = '$' + pwparts[1] + '$' +  pwparts[2] +'$'
+    # calcpasswd = crypt.crypt(password, salt)
+    #
+    # if calcpasswd != readpasswd:
+    
+    # 2021-09-26: Works with all hashes in /etc/shadow (SHA-512, yescrypt, etc) for #2985
+    if subprocess.run(['perl', '-e', f"print crypt('{password}', '{spwddb[1]}')"], capture_output=True, text=True).stdout != spwddb[1]:
         print('Bad Password')
         return False
     else:


### PR DESCRIPTION
Essentially a 1-line fix for all distros, supporting all password hashing schemes in `/etc/shadow` by calling out from Python to PERL, so Admin Console logins work on more modern distros.

Tested on Raspberry Pi OS, Debian 11 Bullseye, and Ubuntu 21.04

Longer-term, @tim-moody may prefer another solution, but this works very well today, to help people like @boholder getting stuck trying to log into Admin Console on Debian 11 Bullseye and similar distros.

Refs:

- iiab/iiab#2985
- PR iiab/iiab-factory#183