### PR TITLE
Upgrade Wikipedia for Schools from 2013 to 2021 in presets/en-school

### DIFF
--- a/roles/cmdsrv/files/presets/en-school/content.json
+++ b/roles/cmdsrv/files/presets/en-school/content.json
@@ -1,7 +1,7 @@
 {
   "zims": [
     "wikipedia_en_top_maxi",
-    "wikipedia_en_for-schools",
+    "wikipedia_en_for_schools_maxi",
     "wikispecies_en_all_maxi",
     "raspberrypi.stackexchange.com_en_all",
     "chemistry.stackexchange.com_en_all",

--- a/roles/cmdsrv/files/presets/en-school/menu.json
+++ b/roles/cmdsrv/files/presets/en-school/menu.json
@@ -23,7 +23,7 @@
   ],
   "menu_items_1": [
       "en-wikipedia_en_top_maxi",
-      "en-wikipedia_en_for-schools",
+      "en-wikipedia_en_for_schools_maxi",
       "en-kalite",
       "en-osm_viewer_v2",
       "en-wikispecies_en_all_maxi",

--- a/roles/cmdsrv/files/presets/en-school/preset.json
+++ b/roles/cmdsrv/files/presets/en-school/preset.json
@@ -3,6 +3,6 @@
   "description": "Content and Features often used by a School with instruction in English",
   "default_lang": "en",
   "location": "Generic",
-  "size_in_gb": 115,
-  "last_modified": "2021-11-14"
+  "size_in_gb": 114,
+  "last_modified": "2021-12-16"
 }


### PR DESCRIPTION
This is not just an update of the articles 8 years later.

The curatorial quality of is also much higher.

And it's smaller (1.1GB instead of 2.4GB !)

Background/Details:

- https://github.com/openzim/zim-requests/issues/350
- http://iiab.me/kiwix/wikipedia_en_for_schools_maxi_2021-10/
- https://en.wikipedia.org/wiki/Wikipedia:Wikipedia_for_Schools/Welcome
- OLD description: https://github.com/iiab-share/js-menu-files/blob/master/menu-defs/en-wikipedia_en_for-schools.json
- NEW description: https://github.com/iiab-share/js-menu-files/blob/master/menu-defs/en-wikipedia_en_for_schools_maxi.json