### PR TITLE
Typos in roles/console/files/htmlf/50-edit_menus.html & roles/console/files/help/ContentMenus.rst

### DIFF
--- a/roles/console/files/help/ContentMenus.rst
+++ b/roles/console/files/help/ContentMenus.rst
@@ -89,7 +89,7 @@ You can edit the Title and other parts of the Menu Items that are on the current
 * Title - Put a short, one line name for the item here. Ideally it would be unique and way shorter than this text.
 * Name of Icon File - This is an image file in /library/www/html/js-menu/menu-files/images. At present we don't validate it. There are **buttons** to select an image file and to upload a new one.
 * Description - Put a fuller description of the item here, but not more than one paragraph.
-* Start URL (Optional) - Only change this if the the blank default doesn't work.
+* Start URL (Optional) - Only change this if the blank default doesn't work.
 * Extra_description - If there is more description, put it here.
 * Sub Menu Html File (Optional) - This is an html file in /library/www/html/js-menu/menu-files/menu-defs. At present we don't validate it.
 * Footnote - You can put catalog type information here like number of pdfs or size. Also you can use the ##SIZE## and other substitution fields for zims.

--- a/roles/console/files/htmlf/50-edit_menus.html
+++ b/roles/console/files/htmlf/50-edit_menus.html
@@ -302,7 +302,7 @@
                             </div>
                           </div>
                           <div class="form-group">
-                            <label for="menu_item_start_url">Optional Start URL - Only change this if the the blank default doesn't work.</label>
+                            <label for="menu_item_start_url">Optional Start URL - Only change this if the blank default doesn't work.</label>
                             <input type="text" name="menu_item_start_url" class="form-control" id="menu_item_start_url">
                           </div>
                           <div class="form-group">


### PR DESCRIPTION
(Until introductory video walkthroughs are recorded, that might effectively modernize and/or replace this kind of written documentation in future, in this era when few people read anymore?)