### PR TITLE
fr-wikistage_fr_all -> fr-wikistage_mul_all in presets/fr-school for @nzola

### DIFF
--- a/roles/cmdsrv/files/presets/fr-school/menu.json
+++ b/roles/cmdsrv/files/presets/fr-school/menu.json
@@ -30,7 +30,7 @@
         "fr-wiktionary_fr_all_maxi",
         "fr-wikiquote_fr_all_maxi",
         "fr-phet_fr",
-        "fr-wikistage_fr_all",
+        "fr-wikistage_mul_all",
         "fr-wikiversity_fr_all_maxi",
         "fr-wikivoyage_fr_all_maxi",
         "fr-biologie-tout-compris_fr_all",


### PR DESCRIPTION
As a result of Kiwix having change the ZIM file name to things like:

- https://download.kiwix.org/zim/videos/wikistage_mul_all_2022-03.zim
- https://download.kiwix.org/zim/videos/wikistage_mul_all_2022-07.zim

Is this minimal PR possibly sufficient?