### PR TITLE
Fix Admin Console install for Ansible 2.14, which disallows 'args:' 'warn: no'

### DIFF
--- a/roles/cmdsrv/tasks/main.yml
+++ b/roles/cmdsrv/tasks/main.yml
@@ -45,7 +45,6 @@
 - name: Install rclone for wasabi
   shell: curl -s https://rclone.org/install.sh | bash -
   args:
-    warn: no
     creates: /usr/bin/rclone
 
 - name: Configure rclone wasabi-iiab-share


### PR DESCRIPTION
Background:

- PR iiab/iiab#3417