### PR TITLE
Restore kiwix-tools 3.4.0 top bar (random button, search)

### DIFF
--- a/iiab-admin.yml
+++ b/iiab-admin.yml
@@ -28,7 +28,7 @@
     cmdsrv_lower_job_priority_flag: "true" # json requires true, not True
     cmdsrv_lower_job_priority_str: "/usr/bin/nice -n19 /usr/bin/ionice -c2 -n7 "
     # because this is not globally in local vars we won't see iiab's role defaults
-    kiwix_url: /kiwix/
+    kiwix_url: /kiwix/viewer#
     kolibri_url: /kolibri
     nodered_port: 1234
 

--- a/js-menu.yml
+++ b/js-menu.yml
@@ -25,7 +25,7 @@
     cmdsrv_lower_job_priority_flag: "true" # json requires true, not True
     cmdsrv_lower_job_priority_str: "/usr/bin/nice -n19 /usr/bin/ionice -c2 -n7 "
     # because this is not globally in local vars we won't see iiab's role defaults
-    kiwix_url: /kiwix/
+    kiwix_url: /kiwix/viewer#
     kolibri_url: /kolibri
     nodered_port: 1234
 


### PR DESCRIPTION
@tim-moody I've changed `/kiwix/` to `/kiwix/viewer#` in both places for now, as kiwix-tools 3.4.0 is now fully released, and as a result is now a part of fresh IIAB installs (as of a few hours ago).

(Is it possible you might prefer to move js-menu.yml to js-menu.yml.unused, e.g. if ./install-menu migrates away from using this file in future?  Just a question; I don't know what's preferred.)

Context: kiwix-tools 3.4.0 requires a different URL to restore the top bar (for search, random button, etc) as summarized here:

- iiab/iiab#3412