### PR TITLE
20-configure.html: Official names for Wikipedias, Calibre-Web, JupyterHub, Remote.It, Asterisk, FreePBX etc

### DIFF
--- a/roles/console/files/htmlf/20-configure.html
+++ b/roles/console/files/htmlf/20-configure.html
@@ -147,7 +147,7 @@
 						<h3>Content Apps</h3>
 						<div class="checkbox kiwix_service">
 							<label>
-								<input type="checkbox" name="kiwix_enabled" id="kiwix_enabled">Kiwix, serves Wikipediae and other content from sources below.  You must also install content.
+								<input type="checkbox" name="kiwix_enabled" id="kiwix_enabled">Kiwix, serves Wikipedias and other content from sources below.  You must also install content.
 							</label>
 						</div>
 						<div class="checkbox kalite_service">
@@ -164,18 +164,18 @@
 
 						<div class="checkbox osm_vector_maps_service">
 							<label>
-								<input type="checkbox" name="osm_vector_maps_enabled" id="osm_vector_maps_enabled">IIAB vector maps are based upon OpenStreetMap Data.  You must also install content.
+								<input type="checkbox" name="osm_vector_maps_enabled" id="osm_vector_maps_enabled">IIAB Maps, to install OpenStreetMap vectors maps for entire continents, and satellite photos for local regions.
 							</label>
 						</div>
 
 						<div class="checkbox calibreweb_service">
 							<label>
-								<input type="checkbox" name="calibreweb_enabled" id="calibreweb_enabled">Calibre Web, a browser based version of Calibre, an E-Book Platform. You must also install content.
+								<input type="checkbox" name="calibreweb_enabled" id="calibreweb_enabled">Calibre-Web, to build your own community E-Book library.  Teachers can add docs, and create bookshelves.
 							</label>
 						</div>
 						<div class="checkbox jupyterhub_service">
 							<label>
-							  <input type="checkbox" name="jupyterhub_enabled" id="jupyterhub_enabled">Jupiter Hub interactive blogging, graphing, and Python programming
+							  <input type="checkbox" name="jupyterhub_enabled" id="jupyterhub_enabled">JupyterHub interactive blogging, graphing, and Python programming
 						  </label>
 						</div>
 
@@ -187,7 +187,7 @@
 
 						<div class="checkbox sugarizer_service">
 							<label>
-								<input type="checkbox" name="sugarizer_enabled" id="sugarizer_enabled">Sugarizer provides Sugar Labs activities directly on the server.
+								<input type="checkbox" name="sugarizer_enabled" id="sugarizer_enabled">Sugarizer provides Sugar Labs activities directly on your IIAB server.
 							</label>
 						</div>
 						<!--
@@ -261,7 +261,7 @@
 						</div>
 						<div class="checkbox pbx_service">
 							<label>
-							  <input type="checkbox" name="pbx_enabled" id="pbx_enabled">PBX a network base local phone system.
+							  <input type="checkbox" name="pbx_enabled" id="pbx_enabled">PBX (including Asterisk and FreePBX) is a network based local phone system.
 						  </label>
 						</div>
 						<div class="checkbox gitea_service">
@@ -310,7 +310,7 @@
 						</div>
 						<div class="checkbox remoteit_service">
 							<label>
-								<input type="checkbox" name="remoteit_enabled" id="remoteit_enabled">RemoteIt another way to connect to external sources of support.
+								<input type="checkbox" name="remoteit_enabled" id="remoteit_enabled">Remote.It is a friendlier way to remotely manage your IIAB server.
 							</label>
 						</div>
 						<!--


### PR DESCRIPTION
1. Better to use IIAB Apps / Services' official names within **Admin Console > Configure > Services Enabled**.

   Also clarifying their practical purpose(s) where possible.

   So this PR tries to make a few improvements in both above areas.

2. [Videos/Explanations/Context for each IIAB App](https://wiki.iiab.io/go/FAQ#What_services_(IIAB_apps)_are_suggested_during_installation%3F) should probably be made available eventually/somehow.

   But I don't know any practical/elegant way to make that happen for now.

   So this PR doesn't even try.