### PR TITLE
Fix links to Kiwix & RACHEL / OER2Go catalogs in docs/5.Content.md

### DIFF
--- a/docs/5.Content.md
+++ b/docs/5.Content.md
@@ -12,9 +12,9 @@ These ZIMS are deployed in /library/zims/content/ and are locally described by t
 
 ### Catalogs
 
-The current catalog is https://library.kiwix.org/catalog/root.xml, which is downloaded by /opt/admin/cmdsrv/scripts/get_kiwix_catalog
+The current catalog is https://library.kiwix.org/catalog/v2/entries?count=-1, which is downloaded by /opt/admin/cmdsrv/scripts/get_kiwix_catalog
 
-(The previous catalog was at https://ftp.nluug.nl/pub/kiwix/library/library_zim.xml, which is obsolescent and not used by IIAB.)
+(The previous catalog were at https://ftp.nluug.nl/pub/kiwix/library/library_zim.xml and  https://library.kiwix.org/catalog/root.xml, which are obsolescent and not used by IIAB.)
 
 get_kiwix_catalog downloads the catalog from Kiwix, parses it, and merges a small catalog of supplementary ZIMS maintained and hosted by IIAB.
 
@@ -80,4 +80,4 @@ As was the case with custom ZIMS you will need to create a Menu Item Definition 
 
 ## Document Version
 
-This document was last maintained on December 29, 2022.
+This document was last maintained on May 22, 2023.

--- a/docs/5.Content.md
+++ b/docs/5.Content.md
@@ -42,7 +42,7 @@ Modules from OER2Go/RACHEL are deployed in /library/www/html/modules. While the 
 
 ### Catalogs
 
-RACHEL has discontinued the catalog at http://dev.worldpossible.org/cgi/json_api_v1.pl in favor of http://oer2go.org/cgi/json_api_v2.pl. But the latter is missing attributes used by the Admin Console, so we use an archived copy.
+RACHEL has discontinued the catalog at http://dev.worldpossible.org/cgi/json_api_v1.pl in favor of https://rachel.worldpossible.org/cgi/json_api_v2.pl. But the latter is missing attributes used by the Admin Console, so we use an archived copy.
 
 When Admin Console is installed roles/cmdsrv/files/json/oer2go_catalog.json is copied to /etc/iiab/oer2go_catalog.json.
 


### PR DESCRIPTION
Any other quick tweaks while we're at it?