### PR TITLE
Allow creation of presets from existing install via Content Menu UI

### DIFF
--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -782,6 +782,7 @@ def cmd_handler(cmd_msg):
         "GET-OSM-VECT-STAT": {"funct": get_osm_vect_stat, "inet_req": False},
         "INST-KALITE": {"funct": install_kalite, "inet_req": True},
         "INST-KOLIBRI": {"funct": install_kolibri, "inet_req": True},
+        "MK-PRESET": {"funct": make_preset, "inet_req": False},
         "DEL-DOWNLOADS": {"funct": del_downloads, "inet_req": False},
         "DEL-MODULES": {"funct": del_modules, "inet_req": False},
         "DEL-CONTENT": {"funct": del_content, "inet_req": False},
@@ -2629,6 +2630,32 @@ def install_presets(cmd_info):
     else:
         resp = cmd_success_msg('INST-PRESETS', "All jobs scheduled")
     return resp
+
+SUPPLIED_PRESETS = {'en-school', 'es-school', 'fr-school', 'en-medical', 'en-school-256-base', 'en-starter', 'test'}
+
+def make_preset(cmd_info):
+    if 'cmd_args' not in cmd_info:
+        return cmd_malformed(cmd_info['cmd'])
+    cmd_args = cmd_info['cmd_args']
+    preset_name = cmd_args.get('preset_name', '')
+    if not preset_name:
+        return cmd_malformed(cmd_info['cmd'])
+    if preset_name in SUPPLIED_PRESETS:
+        return cmd_error(cmd='MK-PRESET', msg="'" + preset_name + "' is a supplied preset and cannot be overwritten.")
+    job_command = "mk-preset.py " + shlex.quote(preset_name)
+    title = cmd_args.get('title', '')
+    description = cmd_args.get('description', '')
+    default_lang = cmd_args.get('default_lang', '')
+    location = cmd_args.get('location', '')
+    if title:
+        job_command += " --title " + shlex.quote(title)
+    if description:
+        job_command += " --description " + shlex.quote(description)
+    if default_lang:
+        job_command += " --lang " + shlex.quote(default_lang)
+    if location:
+        job_command += " --location " + shlex.quote(location)
+    return request_job(cmd_info=cmd_info, job_command=job_command, cmd_step_no=1, depend_on_job_id=-1, has_dependent="N")
 
 def pseudo_cmd_handler(cmd_info, check_dup=True):
     # do some of what cmd_handler does so can call cmd function directly

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -2485,7 +2485,6 @@ def install_presets(cmd_info):
     zim_list = content['zims']
     module_list = content['modules'] # service is web server which is always installed
     map_list = content['maps']
-    kalite_vars = content['kalite']
     needed_services = []
     kolibri_content = content.get('kolibri', {})
     kolibri_channels = kolibri_content.get('channels', [])
@@ -2500,11 +2499,6 @@ def install_presets(cmd_info):
             needed_services.append('OSM Vector Maps')
             vars['osm_vector_maps_install'] = True
             vars['osm_vector_maps_enabled'] = True
-    if len(kalite_vars) > 0:
-        if planned_vars['kalite_install'] != True or planned_vars['kalite_enabled'] != True:
-            needed_services.append('KA Lite')
-            vars['kalite_install'] = True
-            vars['kalite_enabled'] = True
     if len(kolibri_channels) > 0:
         if planned_vars['kolibri_install'] != True or planned_vars['kolibri_enabled'] != True:
             needed_services.append('Kolibri')
@@ -2586,21 +2580,12 @@ def install_presets(cmd_info):
     map_cmd_info = cmd_info
     map_list = content['maps']
     for map in map_list:
+        map_cmd_info = cmd_info
         map_cmd_info['cmd'] = 'INST-OSM-VECT-SET'
         map_cmd_info['cmd_args'] = {'osm_vect_id': map}
         map_cmd_info = pseudo_cmd_handler(map_cmd_info)
         if map_cmd_info:
             resp = install_osm_vect_set(map_cmd_info)
-
-    # kalite
-
-    if len(kalite_vars) > 0:
-        kalite_cmd_info = cmd_info
-        kalite_cmd_info['cmd'] = 'INST-KALITE'
-        kalite_cmd_info['cmd_args'] = content['kalite']
-        kalite_cmd_info = pseudo_cmd_handler(kalite_cmd_info)
-        if kalite_cmd_info:
-            resp = install_kalite(kalite_cmd_info)
 
     # kolibri
     if len(kolibri_channels) > 0:

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -142,6 +142,7 @@ SENSITIVE_COMMANDS = ["CHGPW", "AUTHENTICATE", "CTL-HOTSPOT", "SET-WIFI-CONNECTI
 NO_LOG_COMMANDS = ["AUTHENTICATE"]
 ANSIBLE_COMMANDS = ["RUN-ANSIBLE", "RESET-NETWORK", "RUN-ANSIBLE-ROLES"]
 FULL_LOG_COMMANDS = ["RUN-ANSIBLE", "RESET-NETWORK", "RUN-ANSIBLE-ROLES"]
+SUPPLIED_PRESETS = {'en-school', 'es-school', 'fr-school', 'en-medical', 'en-school-256-base', 'en-starter', 'test'}  # hardcoded list, needs to be updated if presets added
 ansible_running_flag = False
 iiab_roles_status = {}
 daemon_mode = False
@@ -2630,8 +2631,6 @@ def install_presets(cmd_info):
     else:
         resp = cmd_success_msg('INST-PRESETS', "All jobs scheduled")
     return resp
-
-SUPPLIED_PRESETS = {'en-school', 'es-school', 'fr-school', 'en-medical', 'en-school-256-base', 'en-starter', 'test'}
 
 def make_preset(cmd_info):
     if 'cmd_args' not in cmd_info:

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -2482,9 +2482,9 @@ def install_presets(cmd_info):
     # add roles needed by content but not requested
 
     planned_vars = {**effective_vars, **vars}
-    zim_list = content['zims']
-    module_list = content['modules'] # service is web server which is always installed
-    map_list = content['maps']
+    zim_list = content.get('zims', [])
+    module_list = content.get('modules', []) # service is web server which is always installed
+    map_list = content.get('maps', [])
     needed_services = []
     kolibri_content = content.get('kolibri', {})
     kolibri_channels = kolibri_content.get('channels', [])

--- a/roles/cmdsrv/files/presets/en-medical/content.json
+++ b/roles/cmdsrv/files/presets/en-medical/content.json
@@ -19,6 +19,5 @@
     "en-practical_action"
   ],
   "maps": [
-  ],
-  "kalite": {}
+  ]
 }

--- a/roles/cmdsrv/files/presets/en-medical/menu.json
+++ b/roles/cmdsrv/files/presets/en-medical/menu.json
@@ -34,7 +34,6 @@
     "en-fitness_stackexchange_com_en_all",
     "en-health_stackexchange_com_en_all",
     "en-infonet",
-    "en-kalite_health",
     "en-tedmed_en_all",
     "en-cdc",
     "en-practical_action",

--- a/roles/cmdsrv/files/presets/en-school-256-base/content.json
+++ b/roles/cmdsrv/files/presets/en-school-256-base/content.json
@@ -10,7 +10,6 @@
     "satellite_z0-z9_2020.mbtiles",
     "planet_z0-z6_2020.mbtiles"
   ],
-  "kalite": {},
   "kolibri": {
     "lang_code": "en",
     "channels": [{"channel_id": "c9d7f950ab6b5a1199e3d6c10d7f0103"}]

--- a/roles/cmdsrv/files/presets/en-school-256-base/menu.json
+++ b/roles/cmdsrv/files/presets/en-school-256-base/menu.json
@@ -24,7 +24,7 @@
   "menu_items_1": [
       "en-wikipedia_en_all_maxi",
       "en-gutenberg_en_all",
-      "en-kalite",
+      "en-kolibri",
       "en-calibreweb",
       "en-osm_viewer_v2",
       "en-nextcloud",

--- a/roles/cmdsrv/files/presets/en-school/content.json
+++ b/roles/cmdsrv/files/presets/en-school/content.json
@@ -18,7 +18,6 @@
     "satellite_z0-z9_2020.mbtiles",
     "planet_z0-z6_2020.mbtiles"
   ],
-  "kalite": {},
   "kolibri": {
     "lang_code": "en",
     "channels": [{"channel_id": "c9d7f950ab6b5a1199e3d6c10d7f0103"}]

--- a/roles/cmdsrv/files/presets/en-school/menu.json
+++ b/roles/cmdsrv/files/presets/en-school/menu.json
@@ -24,7 +24,7 @@
   "menu_items_1": [
       "en-wikipedia_en_top_maxi",
       "en-wikipedia_en_for_schools_maxi",
-      "en-kalite",
+      "en-kolibri",
       "en-osm_viewer_v2",
       "en-wikispecies_en_all_maxi",
       "en-infonet",

--- a/roles/cmdsrv/files/presets/en-starter/content.json
+++ b/roles/cmdsrv/files/presets/en-starter/content.json
@@ -12,6 +12,4 @@
     "satellite_z0-z9_2020.mbtiles",
     "osm-planet_z0-z10_2020.mbtiles"
   ],
-  "kalite": {
-  }
 }

--- a/roles/cmdsrv/files/presets/es-school/content.json
+++ b/roles/cmdsrv/files/presets/es-school/content.json
@@ -26,7 +26,6 @@
     "osm_central_america_z11-z14_2020.mbtiles",
     "osm-planet_z0-z10_2020.mbtiles"
   ],
-  "kalite": {},
   "kolibri": {
     "lang_code": "es",
     "channels": [{"channel_id": "c1f2b7e6ac9f56a2bb44fa7a48b66dce"}]

--- a/roles/cmdsrv/files/presets/es-school/menu.json
+++ b/roles/cmdsrv/files/presets/es-school/menu.json
@@ -22,7 +22,7 @@
       "Main"
     ],
     "menu_items_1": [
-      "en-kolibri",
+      "es-kolibri",
       "es-wikipedia_es_all_maxi",
       "es-osm_viewer_v2",
       "es-phet_es",

--- a/roles/cmdsrv/files/presets/es-school/menu.json
+++ b/roles/cmdsrv/files/presets/es-school/menu.json
@@ -22,7 +22,7 @@
       "Main"
     ],
     "menu_items_1": [
-      "es-kalite",
+      "en-kolibri",
       "es-wikipedia_es_all_maxi",
       "es-osm_viewer_v2",
       "es-phet_es",

--- a/roles/cmdsrv/files/presets/fr-school/content.json
+++ b/roles/cmdsrv/files/presets/fr-school/content.json
@@ -23,7 +23,6 @@
       "satellite_z0-z9_2020.mbtiles",
       "osm-planet_z0-z10_2020.mbtiles"
     ],
-    "kalite": {},
     "kolibri": {
       "lang_code": "fr",
       "channels": [{"channel_id": "878ec2e6f88c5c268b1be6f202833cd4"}]

--- a/roles/cmdsrv/files/presets/fr-school/menu.json
+++ b/roles/cmdsrv/files/presets/fr-school/menu.json
@@ -24,7 +24,7 @@
     "menu_items_1": [
         "fr-wikipedia_fr_all_maxi",
         "fr-osm_viewer_v2",
-        "en-kolibri",
+        "fr-kolibri",
         "fr-vikidia_fr_all_maxi",
         "fr-les-fondamentaux_fr_all",
         "fr-wiktionary_fr_all_maxi",

--- a/roles/cmdsrv/files/presets/fr-school/menu.json
+++ b/roles/cmdsrv/files/presets/fr-school/menu.json
@@ -24,7 +24,7 @@
     "menu_items_1": [
         "fr-wikipedia_fr_all_maxi",
         "fr-osm_viewer_v2",
-        "fr-kalite_en",
+        "en-kolibri",
         "fr-vikidia_fr_all_maxi",
         "fr-les-fondamentaux_fr_all",
         "fr-wiktionary_fr_all_maxi",

--- a/roles/cmdsrv/files/presets/test/content.json
+++ b/roles/cmdsrv/files/presets/test/content.json
@@ -10,7 +10,6 @@
     "maps": [
       "satellite_z0-z9_2020.mbtiles"
     ],
-    "kalite": {},
     "kolibri": {
       "lang_code": "en",
       "channels": [{"channel_id": "c9d7f950ab6b5a1199e3d6c10d7f0103", "node_id": "a70e92db178d59669d5a7dfe50571ffb"}]

--- a/roles/cmdsrv/files/presets/test/menu.json
+++ b/roles/cmdsrv/files/presets/test/menu.json
@@ -22,7 +22,7 @@
       "Main"
     ],
     "menu_items_1": [
-      "es-kalite",
+      "en-kolibri",
       "es-wikipedia_es_all_maxi",
       "es-osm-omt_central_america",
       "en-osm_viewer_v2",

--- a/roles/cmdsrv/tasks/main.yml
+++ b/roles/cmdsrv/tasks/main.yml
@@ -182,6 +182,7 @@
             - utilities/iiab-sync-menu-defs
             - utilities/iiab-update-menus
             - utilities/iiab-upgrade-zims
+            - utilities/mk-preset.py
 
 - name: Copy default kiwix_catalog.json
   copy: src="json/kiwix_catalog.json"

--- a/roles/cmdsrv/templates/utilities/mk-preset.py
+++ b/roles/cmdsrv/templates/utilities/mk-preset.py
@@ -20,6 +20,7 @@ content["zims"] = []
 content["modules"] = []
 content["maps"] = []
 content["kalite"] = {}
+content["kolibri"] = {}
 
 kalite_topics = []
 
@@ -118,6 +119,14 @@ def do_content(this_preset_dir, noscan):
         get_kalite_complete('khan/', lang)
         content["kalite"]["topics"] = kalite_topics
 
+
+    content["kolibri"] = old_content.get("kolibri", {})
+    if role_stats['kolibri']['active']:
+        lang = get_kolibri_lang()
+        content["kolibri"]["channels"] = get_kolibri_channels()
+        if lang:
+            content["kolibri"]["lang_code"] = lang
+
     adm.write_json_file(content, content_file)
 
 def content_from_files():
@@ -150,6 +159,22 @@ def content_from_menu(this_preset_dir):
                  content["modules"].append(all_menu_defs[menu_def]["moddir"])
             elif all_menu_defs[menu_def]["intended_use"] == "zim":
                 content["zims"].append(all_menu_defs[menu_def]["zim_name"])
+
+def get_kolibri_channels():
+    kolibri_db = '/library/kolibri/db.sqlite3'
+    conn = sqlite3.connect(kolibri_db)
+    cur = conn.execute('SELECT id FROM content_channelmetadata WHERE partial = 0')
+    rows = cur.fetchall()
+    conn.close()
+    return [{'channel_id': row[0]} for row in rows]
+
+def get_kolibri_lang():
+    kolibri_db = '/library/kolibri/db.sqlite3'
+    conn = sqlite3.connect(kolibri_db)
+    cur = conn.execute('SELECT language_id FROM device_devicesettings LIMIT 1')
+    row = cur.fetchone()
+    conn.close()
+    return row[0] if row and row[0] else None
 
 def get_kalite_lang():
     # assumes normal, not PRESETS install

--- a/roles/cmdsrv/templates/utilities/mk-preset.py
+++ b/roles/cmdsrv/templates/utilities/mk-preset.py
@@ -30,6 +30,10 @@ def main():
     parser.add_argument("preset", help="The name of the preset. Is the directory in which the json files are store.")
     parser.add_argument("-m", "--menu", type=str, default='home', required=False, help="source menu (default home)")
     parser.add_argument("-n", "--noscan", help="do not scan file system for content, but rather use the menu", action="store_true")
+    parser.add_argument("--title", type=str, default=None, required=False, help="preset title (name field in preset.json)")
+    parser.add_argument("--description", type=str, default=None, required=False, help="preset description")
+    parser.add_argument("--lang", type=str, default=None, required=False, help="default language code")
+    parser.add_argument("--location", type=str, default=None, required=False, help="location this was installed")
     # from_menu T/F
     # menu_dir
     args =  parser.parse_args()
@@ -44,20 +48,20 @@ def main():
 
     role_stats = adm.get_roles_status()
 
-    do_preset(this_preset_dir)
+    do_preset(this_preset_dir, args.title, args.description, args.lang, args.location)
     do_menu(this_preset_dir, args.menu)
     do_vars(this_preset_dir)
     do_content(this_preset_dir, args.noscan)
 
     sys.exit()
 
-def do_preset(this_preset_dir):
+def do_preset(this_preset_dir, title=None, description=None, lang=None, location=None):
     preset_file = this_preset_dir + 'preset.json'
     preset = {}
-    preset["name"] = "Put a name or title here"
-    preset["description"] = "Put a longer description here"
-    preset["default_lang"] = "en or another code"
-    preset["location"] = "Optional location this was installed"
+    preset["name"] = title if title else "Put a name or title here"
+    preset["description"] = description if description else ""
+    preset["default_lang"] = lang if lang else ""
+    preset["location"] = location if location else ""
     space_avail = adm.calc_space_avail()
     root_size_in_k = int(space_avail['root']['size_in_k']) - int(space_avail['root']['avail_in_k'] )
     if 'library' in space_avail:

--- a/roles/cmdsrv/templates/utilities/mk-preset.py
+++ b/roles/cmdsrv/templates/utilities/mk-preset.py
@@ -167,7 +167,7 @@ def content_from_menu(this_preset_dir):
 def get_kolibri_channels():
     kolibri_db = '/library/kolibri/db.sqlite3'
     conn = sqlite3.connect(kolibri_db)
-    cur = conn.execute('SELECT id FROM content_channelmetadata WHERE partial = 0')
+    cur = conn.execute('SELECT id FROM content_channelmetadata WHERE partial = 0')  # partial = 0 means fully downloaded
     rows = cur.fetchall()
     conn.close()
     return [{'channel_id': row[0]} for row in rows]

--- a/roles/console/files/htmlf/40-install_content.html
+++ b/roles/console/files/htmlf/40-install_content.html
@@ -21,8 +21,8 @@
         <li><a href="#instConOer2go" call-after="oer2goMenuOption">Get OER2Go(RACHEL) Modules</a></li>
         <li><a href="#instOsmRegion" call-after="renderRegionMap">Get Map Regions</a></li>
         <li><a href="#instOsmAddons" call-after="renderAddonsMap">Get Map Addons</a></li>
-        <!-- <li><a href="#instConKAlite">Download Khan Academy Videos</a></li> -->
         <li><a href="#instManageContent" call-after="manageContentInit">Manage Content</a></li>
+        <li><a href="#instMakePreset" call-after="getPresetList">Create a Content Collection</a></li>
         <li id="instConCloneLink" style="display:none"><a href="#instCloneServer" call-after="getIiabCloneStats">Clone
             IIAB</a></li>
         <!-- <li><a href="#instRemoveContent" call-after="refreshAllInstalledList">Remove Content</a></li> -->
@@ -299,6 +299,39 @@
             </div>
           </div>
         </div> <!--  End instManageContent Submenu Option Pane -->
+
+        <div class="tab-pane" id="instMakePreset">
+          <!-- Start instMakePreset Submenu Option Pane -->
+          <h2>Create a Content Collection</h2>
+          <p>Save the content currently installed on this box as a preset that can be installed on other boxes.</p>
+          <div class="row">
+            <div class="col-sm-6">
+              <form>
+                <div class="form-group">
+                  <label for="mkPresetName">Preset name</label>
+                  <input type="text" class="form-control" id="mkPresetName" placeholder="no spaces">
+                </div>
+                <div class="form-group">
+                  <label for="mkPresetTitle">Title</label>
+                  <input type="text" class="form-control" id="mkPresetTitle">
+                </div>
+                <div class="form-group">
+                  <label for="mkPresetDescription">Description</label>
+                  <input type="text" class="form-control" id="mkPresetDescription">
+                </div>
+                <div class="form-group">
+                  <label for="mkPresetLang">Default language (optional)</label>
+                  <input type="text" class="form-control" id="mkPresetLang" placeholder="e.g. en">
+                </div>
+                <div class="form-group">
+                  <label for="mkPresetLocation">Location (optional)</label>
+                  <input type="text" class="form-control" id="mkPresetLocation">
+                </div>
+              </form>
+            </div>
+          </div>
+          <button id="MK-PRESET" type="button" class="btn btn-lg btn-primary">Create</button>
+        </div> <!--  End instMakePreset Submenu Option Pane -->
 
         <div class="tab-pane" id="instCloneServer">
           <!-- Start instCloneServer Submenu Option Pane -->

--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -473,6 +473,7 @@ function instContentButtonsEvents() {
       return;
     }
     var suppliedPresets = ['en-school', 'es-school', 'fr-school', 'en-medical', 'en-school-256-base', 'en-starter', 'test'];
+    // skip confirm for supplied presets to avoid two dialogs
     if (presetName in presetList && suppliedPresets.indexOf(presetName) === -1) {
       if (!confirm("Preset '" + presetName + "' already exists. Overwrite?"))
         return;

--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -449,6 +449,37 @@ function instContentButtonsEvents() {
     getOer2goCatalog();
   });
 
+  $("#MK-PRESET").click(function(){
+    var presetName = $("#mkPresetName").val().trim();
+    var title = $("#mkPresetTitle").val().trim();
+    var description = $("#mkPresetDescription").val().trim();
+    var defaultLang = $("#mkPresetLang").val().trim();
+    var location = $("#mkPresetLocation").val().trim();
+
+    if (!presetName) {
+      alert("Preset name is required.");
+      return;
+    }
+    if (/\s/.test(presetName)) {
+      alert("Preset name must not contain spaces.");
+      return;
+    }
+    if (!title) {
+      alert("Title is required.");
+      return;
+    }
+    if (!description) {
+      alert("Description is required.");
+      return;
+    }
+    var suppliedPresets = ['en-school', 'es-school', 'fr-school', 'en-medical', 'en-school-256-base', 'en-starter', 'test'];
+    if (presetName in presetList && suppliedPresets.indexOf(presetName) === -1) {
+      if (!confirm("Preset '" + presetName + "' already exists. Overwrite?"))
+        return;
+    }
+    makePreset(presetName, title, description, defaultLang, location);
+  });
+
   $("#DOWNLOAD-RACHEL").click(function(){
   	if (rachelStat.content_installed == true){
   	  var rc = confirm("RACHEL content is already in the library.  Are you sure you want to download again?");

--- a/roles/console/files/js/content_functions.js
+++ b/roles/console/files/js/content_functions.js
@@ -706,6 +706,19 @@ function instCloneServerDevicesHtml(dev, devSize, checked){
   return(html);
 }
 
+function makePreset(presetName, title, description, defaultLang, location) {
+  var cmd_args = {};
+  cmd_args['preset_name'] = presetName;
+  cmd_args['title'] = title;
+  cmd_args['description'] = description;
+  cmd_args['default_lang'] = defaultLang;
+  cmd_args['location'] = location;
+  var cmd = "MK-PRESET " + JSON.stringify(cmd_args);
+  return sendCmdSrvCmd(cmd, function() {
+    alert("Content collection '" + presetName + "' created.\n\nPlease view Utilities->Display Job Status to see the results.");
+  }, "MK-PRESET");
+}
+
 function copyDevImage(){
   var selectedDevice = $('input[name="selRemDevice"]:checked').val();
 

--- a/roles/js-menu/files/menu-files/menu-defs/en-kolibri.json
+++ b/roles/js-menu/files/menu-files/menu-defs/en-kolibri.json
@@ -5,6 +5,6 @@
   "menu_item_name" : "en-kolibri",
   "title" : "Kolibri",
   "start_url" : "/",
-  "description" : "Kolibri (might replace KA Lite in future!) provides offline access to a wide range of quality, openly licensed educational content.",
+  "description" : "Kolibri provides offline access to a wide range of quality, openly licensed educational content.",
   "extra_html" : "en-kolibri.html"
 }


### PR DESCRIPTION
Part 2 (final part), closes #623 . Also resolves #624 and #626 .  Tested multiple scenarios as seen below, running on VirtualBox with Ubuntu 24.04.4.

The Content Menu now has a "Create a Content Collection" panel that allows users to create a preset from their existing install, including Kolibri channels. All the fields in preset.json can be filled in, except for size_in_gb and last_modified, which are computed automatically.

<img width="2624" height="1528" alt="image" src="https://github.com/user-attachments/assets/b5fa6d48-eabb-46c7-982b-b678e761cba4" />

### Test scenario with successful creation and import

Clicking "Create" triggers mk-preset.py. For instance, in this test case I am creating a preset after downloading the PointB Kolibri channel.

<img width="2238" height="120" alt="image" src="https://github.com/user-attachments/assets/9edacb89-b734-453c-822d-18e13b9a7b11" />


In Install Content > Quick Pick, the user will then see their new preset in the list.

<img width="1053" height="176" alt="image" src="https://github.com/user-attachments/assets/886cc0b9-dcbd-41e8-b0c7-635b29cc116b" />

And when they import that preset, the PointB Kolibri channel `"channel_id": "254f1b384c2551ed80ada423449212a1"` is automatically downloaded.

<img width="2270" height="278" alt="image" src="https://github.com/user-attachments/assets/c3464fc8-f60f-40e1-9f32-68bdb0a6c8e6" />

### Test scenario where the preset name filled in by the user is the same as a supplied preset name. 

Creation of the preset is blocked.

<img width="1490" height="562" alt="image" src="https://github.com/user-attachments/assets/9102731f-e4fa-4ae9-96e9-8109a1a8074e" />

### Test scenario where the preset name filled in by the user is the same as an existing preset name, but NOT a supplied preset name.

A warning is shown and the user can choose to overwrite if desired.

<img width="1420" height="529" alt="image" src="https://github.com/user-attachments/assets/8cfc16f6-a681-4d2a-bc4b-b0547e1ba015" />

