### PR TITLE
Add "select/deselect all" checkbox to Job Status

### DIFF
--- a/roles/console/files/css/iiab.css
+++ b/roles/console/files/css/iiab.css
@@ -236,6 +236,10 @@ text-align: center;
 	margin-top: 20px;
 }
 
+.job-complete {
+	opacity: 0.70;
+}
+
 .jobTable {
 	width:100%;
 	padding: 4px;

--- a/roles/console/files/htmlf/70-utilities.html
+++ b/roles/console/files/htmlf/70-utilities.html
@@ -56,18 +56,22 @@
 						<div class="col-sm-2"><button id="JOB-STATUS-REFRESH" type="button" class="btn btn-lg btn-primary">Refresh Status</button></div>
 						-->
 
-						<div class="col-sm-3"><button id="CANCEL-JOBS" type="button" class="btn btn-lg btn-primary">Cancel Checked Jobs</button></div>
-						<div class="col-sm-4"><span id="statusJobsRefreshTime">Last Refreshed: <b>10/28/2021, 8:00:10 AM</b></span></div>
-						<div class="col-sm-3">
-							<button id="JOB-STATUS-REFRESH" type="button" class="btn btn-lg btn-primary">Refresh Status</button>
-							<button id="JOB-STATUS-MORE" type="button" class="btn btn-lg btn-primary">More Jobs</button>
+						<div class="col-sm-12">
+							<div style="display:flex; align-items:center; gap:15px">
+								<div><button id="CANCEL-JOBS" type="button" class="btn btn-lg btn-primary">Cancel Checked Jobs</button></div>
+								<div style="flex:1"><span id="statusJobsRefreshTime">Last Refreshed: <b>10/28/2021, 8:00:10 AM</b></span></div>
+								<div style="white-space:nowrap">
+									<button id="JOB-STATUS-REFRESH" type="button" class="btn btn-lg btn-primary">Refresh Status</button>
+									<button id="JOB-STATUS-MORE" type="button" class="btn btn-lg btn-primary">More Jobs</button>
+								</div>
+							</div>
 						</div>
 					</div>
 					<div id=jobStatTable> <!--  Start jobStatTable -->
 						<table class="jobTable table-striped table-bordered">
 							<thead>
 								<tr>
-									<th style="width:10%">#</th>
+									<th style="width:10%"><input type="checkbox" id="selectAllJobs" title="Select/deselect all jobs"> #</th>
 									<th style="width:30%">Command</th>
 									<th style="width:40%">Result</th>
 									<th style="width:10%">Status</th>

--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -601,7 +601,8 @@ function utilButtonsEvents() {
   $("#CANCEL-JOBS").click(function(){
   	var cmdList = [];
     make_button_disabled("#CANCEL-JOBS", true);
-    $('#jobStatTable input').each( function(){
+    // Prevent iteration over the "select all" checkbox to avoid "Malformed Command CANCEL-JOB" error
+    $('#jobStatTable tbody input').each( function(){
       if (this.type == "checkbox")
         if (this.checked){
           var job_idArr = this.id.split('-');
@@ -626,6 +627,11 @@ function utilButtonsEvents() {
     $.when.apply($, cmdList).then(getJobStat, procZimCatalog);
     alert ("Jobs marked for Cancellation.\n\nPlease click Refresh to see the results.");
     make_button_disabled("#CANCEL-JOBS", false);
+  });
+
+  $("#selectAllJobs").click(function() {
+    var checked = this.checked;
+    $('#jobStatTable input[type="checkbox"]:not([disabled])').prop('checked', checked);
   });
 
   $("#GET-INET-SPEED").click(function(){
@@ -1668,12 +1674,14 @@ function procJobStat(data)
 
   data.forEach(function(statusJob) {
     //console.log(statusJob);
-    html += "<tr>";
+    var terminalStatuses = ['SUCCEEDED', 'FAILED', 'CANCELLED'];
+    var isTerminal = terminalStatuses.indexOf(statusJob.job_status) >= 0;
+    html += isTerminal ? '<tr class="job-complete">' : "<tr>";
     //var job_info = {};
 
     //job_info['job_no'] = entry[0];
     html += "<td>";
-    html += '<input type="checkbox" id="' + statusJob.job_id + '">';
+    html += '<input type="checkbox" id="' + statusJob.job_id + '"' + (isTerminal ? ' disabled' : '') + '>';
     html += '<span style="vertical-align: text-bottom;">&nbsp;&nbsp;' + statusJob.job_id + '</span>';
     html += "</td>";
     html += '<td style="overflow: hidden; text-overflow: ellipsis">' + statusJob.job_command + "</td>";
@@ -1728,6 +1736,8 @@ function procJobStat(data)
     make_button_disabled("#JOB-STATUS-MORE", true);
   else
     make_button_disabled("#JOB-STATUS-MORE", false);
+
+  $('#selectAllJobs').prop('checked', false);
 
 }
 


### PR DESCRIPTION
Fixes #636 .

### 1. Added checkbox in Job Status table that selects all or deselects all when clicked

Users can also manually deselect individual jobs after clicking "select all". 

Jobs with the status 'SUCCEEDED', 'FAILED', or 'CANCELLED' can't be selected. They are also slightly greyed out to emphasize the difference - I can tweak the opacity or just remove this style change if it doesn't suit.

<img width="2848" height="1721" alt="image" src="https://github.com/user-attachments/assets/c494bb9f-23bb-4a67-961f-5c980da5d501" />

### 2. Fixed layout of "More jobs" button in smaller viewports

<img width="1488" height="503" alt="image" src="https://github.com/user-attachments/assets/7754575f-b4b1-4026-a6c7-991866463fe9" />
