### PR TITLE
Add job status and age filter, add automatic refresh on cancelling jobs

### DIFF
--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -3568,9 +3568,16 @@ def get_last_jobs_stat(cmd_info):
     if last_rowid == 1:
         last_rowid = 10000 # wrap to refresh
 
+    try:
+        since_days = int(cmd_info['cmd_args'].get('since_days', 0))
+    except:
+        since_days = 0
+
     sql_cmd = "SELECT jobs.rowid, job_command, job_output, job_status, strftime('%m-%d %H:%M', jobs.create_datetime), "
     sql_cmd += "strftime('%s', jobs.create_datetime), strftime('%s',last_update_datetime), strftime('%s','now', 'localtime'), cmd_msg "
     sql_cmd += "FROM jobs, commands where cmd_rowid = commands.rowid AND jobs.rowid < " + str(last_rowid)
+    if since_days > 0:
+        sql_cmd += " AND jobs.create_datetime >= datetime('now', '-" + str(since_days) + " days', 'localtime')"
     sql_cmd += " ORDER BY jobs.rowid DESC LIMIT 50"
 
     db_lock.acquire() # will block if lock is already held

--- a/roles/console/files/htmlf/70-utilities.html
+++ b/roles/console/files/htmlf/70-utilities.html
@@ -67,6 +67,27 @@
 							</div>
 						</div>
 					</div>
+					<div class="row" style="margin-top:8px;">
+						<div class="col-sm-12">
+							<div style="display:flex; align-items:center; gap:16px; flex-wrap:wrap;">
+								<span><b>Show:</b></span>
+								<label style="margin:0; cursor:pointer;"><input type="checkbox" class="job-status-filter" data-statuses="SCHEDULED" checked> Scheduled</label>
+								<label style="margin:0; cursor:pointer;"><input type="checkbox" class="job-status-filter" data-statuses="STARTED,RESTARTED" checked> In Progress</label>
+								<label style="margin:0; cursor:pointer;"><input type="checkbox" class="job-status-filter" data-statuses="SUCCEEDED" checked> Succeeded</label>
+								<label style="margin:0; cursor:pointer;"><input type="checkbox" class="job-status-filter" data-statuses="FAILED" checked> Failed</label>
+								<label style="margin:0; cursor:pointer;"><input type="checkbox" class="job-status-filter" data-statuses="CANCELLED" checked> Cancelled</label>
+								<span style="border-left:1px solid #ccc; height:18px; display:inline-block;"></span>
+								<label style="margin:0;">Age:
+									<select id="jobStatusAge">
+										<option value="1">Last 24h</option>
+										<option value="3" selected>Last 3 days</option>
+										<option value="7">Last week</option>
+										<option value="0">All time</option>
+									</select>
+								</label>
+							</div>
+						</div>
+					</div>
 					<div id=jobStatTable> <!--  Start jobStatTable -->
 						<table class="jobTable table-striped table-bordered">
 							<thead>

--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -20,6 +20,7 @@ var iiab_ini = {};
 var allJobsStatus = {};
 var jobActiveSum = {};
 var jobStatusLastRowid = 1 // trigger refresh
+var jobStatusAgeDays = 3;
 var langCodes = {}; // iso code, local name and English name for all languages we support, read from file
 var langCodesXRef = {}; // lookup langCodes key by iso2
 var zimCatalog = {}; // working composite catalog of kiwix, installed, and wip zims
@@ -633,6 +634,20 @@ function utilButtonsEvents() {
     var checked = this.checked;
     $('#jobStatTable input[type="checkbox"]:not([disabled])').prop('checked', checked);
   });
+
+  $(".job-status-filter").change(function() {
+    saveJobFilterPrefs();
+    applyJobStatusFilter();
+  });
+
+  $("#jobStatusAge").change(function() {
+    jobStatusAgeDays = parseInt($(this).val()) || 0;
+    saveJobFilterPrefs();
+    jobStatusLastRowid = 1;
+    getJobStat();
+  });
+
+  loadJobFilterPrefs();
 
   $("#GET-INET-SPEED").click(function(){
     getInetSpeed();
@@ -1659,6 +1674,7 @@ function getJobStat()
   var cmd_args = {};
 
   cmd_args['last_rowid'] = jobStatusLastRowid;
+  cmd_args['since_days'] = jobStatusAgeDays;
   cmd = command + " " + JSON.stringify(cmd_args);
   sendCmdSrvCmd(cmd, procJobStat);
   return true;
@@ -1669,11 +1685,31 @@ function procJobStat(data)
   allJobsStatus = {};
   jobStatusLastRowid = 1
 
+  data.forEach(function(statusJob) {
+    consoleLog(statusJob);
+    allJobsStatus[statusJob.job_id] = statusJob;
+    jobStatusLastRowid = statusJob.job_id // save lowest rowid seen
+  });
+
+  applyJobStatusFilter();
+
+  today = new Date();
+  $( "#statusJobsRefreshTime" ).html("Last Refreshed: <b>" + today.toLocaleString() + "</b>");
+  if (jobStatusLastRowid == 1)
+    make_button_disabled("#JOB-STATUS-MORE", true);
+  else
+    make_button_disabled("#JOB-STATUS-MORE", false);
+
+  $('#selectAllJobs').prop('checked', false);
+
+}
+
+function renderJobRows(jobs)
+{
   var html = "";
   var html_break = '<br>';
 
-  data.forEach(function(statusJob) {
-    //console.log(statusJob);
+  jobs.forEach(function(statusJob) {
     var terminalStatuses = ['SUCCEEDED', 'FAILED', 'CANCELLED'];
     var isTerminal = terminalStatuses.indexOf(statusJob.job_status) >= 0;
     html += isTerminal ? '<tr class="job-complete">' : "<tr>";
@@ -1721,24 +1757,60 @@ function procJobStat(data)
     //else
     //  statusJob['cmd_args'] = JSON.parse(cmd_parse[1]);
 
-    consoleLog(statusJob);
-    allJobsStatus[statusJob.job_id] = statusJob;
-    jobStatusLastRowid = statusJob.job_id // save lowest rowid seen
-
   });
   $( "#jobStatTable tbody" ).html(html);
   $( "#jobStatTable div.statusJobResult" ).each(function( index ) {
     $(this).scrollTop(this.scrollHeight);
   });
-  today = new Date();
-  $( "#statusJobsRefreshTime" ).html("Last Refreshed: <b>" + today.toLocaleString() + "</b>");
-  if (jobStatusLastRowid == 1)
-    make_button_disabled("#JOB-STATUS-MORE", true);
-  else
-    make_button_disabled("#JOB-STATUS-MORE", false);
+}
 
-  $('#selectAllJobs').prop('checked', false);
+function getActiveStatusFilters()
+{
+  var statuses = [];
+  $('.job-status-filter:checked').each(function() {
+    var s = $(this).data('statuses').split(',');
+    statuses = statuses.concat(s);
+  });
+  return statuses;
+}
 
+function applyJobStatusFilter()
+{
+  var activeStatuses = getActiveStatusFilters();
+  var jobs = Object.values(allJobsStatus);
+  jobs.sort(function(a, b) { return b.job_id - a.job_id; });
+  // if all or none are checked, show everything
+  if (activeStatuses.length > 0 && activeStatuses.length < 6) {
+    jobs = jobs.filter(function(j) {
+      return activeStatuses.indexOf(j.job_status) >= 0;
+    });
+  }
+  renderJobRows(jobs);
+}
+
+function loadJobFilterPrefs()
+{
+  var savedStatuses = localStorage.getItem("jobStatusFilter");
+  if (savedStatuses !== null) {
+    var activeList = savedStatuses === "" ? [] : savedStatuses.split(',');
+    $('.job-status-filter').each(function() {
+      var checkboxStatuses = $(this).data('statuses').split(',');
+      var anyMatch = checkboxStatuses.some(function(s) { return activeList.indexOf(s) >= 0; });
+      $(this).prop('checked', anyMatch);
+    });
+  }
+  var savedAge = localStorage.getItem("jobStatusAgeDays");
+  if (savedAge !== null) {
+    jobStatusAgeDays = parseInt(savedAge) || 0;
+    $('#jobStatusAge').val(String(jobStatusAgeDays));
+  }
+}
+
+function saveJobFilterPrefs()
+{
+  var statuses = getActiveStatusFilters();
+  localStorage.setItem("jobStatusFilter", statuses.join(','));
+  localStorage.setItem("jobStatusAgeDays", String(jobStatusAgeDays));
 }
 
 function cancelJob(job_id)

--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -625,13 +625,9 @@ function utilButtonsEvents() {
         }
     });
     //consoleLog(cmdList);
-    // use Promise.all to wait for all cancels
-    // delay 1.5s so backend has time to update job status before we refresh
-    Promise.all(cmdList).then(function() {
-      setTimeout(function() {
-        jobStatusLastRowid = 1; // trigger refresh from most recent
-        getJobStat();
-      }, 1500);
+    $.when.apply($, cmdList).then(function() {
+      jobStatusLastRowid = 1; // trigger refresh from most recent
+      getJobStat();
     });
     alert ("Jobs marked for Cancellation.");
     make_button_disabled("#CANCEL-JOBS", false);
@@ -1837,7 +1833,12 @@ function cancelJobFunc(job_id)
   var cmd_args = {}
   cmd_args['job_id'] = job_id;
   cmd = command + " " + JSON.stringify(cmd_args);
-  return sendCmdSrvCmd(cmd, genericCmdHandler);
+  var deferred = $.Deferred();
+  sendCmdSrvCmd(cmd, function(data) {
+    genericCmdHandler(data);
+    deferred.resolve();
+  });
+  return deferred.promise();
 }
 
 function getRpiState()

--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -625,8 +625,15 @@ function utilButtonsEvents() {
         }
     });
     //consoleLog(cmdList);
-    $.when.apply($, cmdList).then(getJobStat, procZimCatalog);
-    alert ("Jobs marked for Cancellation.\n\nPlease click Refresh to see the results.");
+    // use Promise.all to wait for all cancels
+    // delay 1.5s so backend has time to update job status before we refresh
+    Promise.all(cmdList).then(function() {
+      setTimeout(function() {
+        jobStatusLastRowid = 1; // trigger refresh from most recent
+        getJobStat();
+      }, 1500);
+    });
+    alert ("Jobs marked for Cancellation.");
     make_button_disabled("#CANCEL-JOBS", false);
   });
 
@@ -1704,6 +1711,7 @@ function procJobStat(data)
 
 }
 
+// split from procJobStat so filters can re-render without re-fetching from server
 function renderJobRows(jobs)
 {
   var html = "";
@@ -1779,8 +1787,8 @@ function applyJobStatusFilter()
   var activeStatuses = getActiveStatusFilters();
   var jobs = Object.values(allJobsStatus);
   jobs.sort(function(a, b) { return b.job_id - a.job_id; });
-  // if all or none are checked, show everything
-  if (activeStatuses.length > 0 && activeStatuses.length < 6) {
+  // 6 = total statuses, update this if new statuses are added to the filter
+  if (activeStatuses.length < 6) {
     jobs = jobs.filter(function(j) {
       return activeStatuses.indexOf(j.job_status) >= 0;
     });
@@ -1829,10 +1837,7 @@ function cancelJobFunc(job_id)
   var cmd_args = {}
   cmd_args['job_id'] = job_id;
   cmd = command + " " + JSON.stringify(cmd_args);
-  return $.Deferred( function () {
-  	var self = this;
-  	sendCmdSrvCmd(cmd, genericCmdHandler);
-  	});
+  return sendCmdSrvCmd(cmd, genericCmdHandler);
 }
 
 function getRpiState()


### PR DESCRIPTION
Addresses [this discussion](https://github.com/iiab/iiab/discussions/4337). 

### 1. Add status and age filter for jobs

<img width="2824" height="354" alt="image" src="https://github.com/user-attachments/assets/f2e50a07-9493-43b7-acfe-571832bf521e" />

- Checkboxes allow user to show or hide jobs by status: Scheduled, In Progress (covers both STARTED and RESTARTED), Succeeded, Failed, Cancelled. 
- Age dropdown limits how far back jobs are fetched: Last 24h, Last 3 days, Last week, All time. 
- Default: All job statuses for the last 3 days.
- Filter preferences are saved to localStorage and restored on next visit.

### 2. Add automatic refresh after cancelling jobs

- After cancelling jobs, the table now refreshes automatically instead of asking the user to click refresh. 
- Implemented 1.5s delay to give the backend time to process cancellations before the refresh fires.
- cancelJobFunc previously returned a `$.Deferred` that was never resolved, so the post-cancel refresh never fired. Fixed by returning the native `Promise` from `sendCmdSrvCmd` directly, and switching from `$.when.apply` to `Promise.all`.
