### PR TITLE
Add "Display Hardware Info" to Utilities menu 

### DIFF
--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -735,6 +735,7 @@ def cmd_handler(cmd_msg):
         "SET-CONF": {"funct": set_config_vars, "inet_req": False},
         "GET-RPI-STATE": {"funct": get_rpi_state, "inet_req": False},
         "GET-MEM-INFO": {"funct": get_mem_info, "inet_req": False},
+        "GET-HW-INFO": {"funct": get_hw_info, "inet_req": False},
         "GET-SPACE-AVAIL": {"funct": get_space_avail, "inet_req": False},
         "GET-STORAGE-INFO": {"funct": get_storage_info_lite, "inet_req": False},
         "GET-EXTDEV-INFO": {"funct": get_external_device_info, "inet_req": False},
@@ -1188,6 +1189,14 @@ def get_mem_info(cmd_info):
     outp = subproc_check_output(["/usr/bin/free", "-h"])
     json_outp = json_array("system_memory", outp)
     return (json_outp)
+
+def get_hw_info(cmd_info):
+    try:
+        outp = subproc_check_output(["/usr/bin/lshw", "-json", "-quiet", "-sanitize"])
+        resp = '{"hw_info": ' + outp + '}'
+    except Exception:
+        resp = cmd_error(cmd_info['cmd'], "Unable to read hardware info")
+    return (resp)
 
 def get_space_avail(cmd_info):
     space_avail = adm.calc_space_avail()

--- a/roles/console/files/htmlf/70-utilities.html
+++ b/roles/console/files/htmlf/70-utilities.html
@@ -19,6 +19,7 @@
 					call-after="getRpiState">Display System Status</a></li>
 				<li><a href="#utilsMemory" call-after="getSysMem">Display System Memory</a></li>
 				<li><a href="#utilsStorage" call-after="getSysStorage">Display System Storage</a></li>
+				<li><a href="#utilsHwInfo" call-after="getHwInfo">Display Hardware Info</a></li>
 				<li><a href="#utilsSpeedTest">Perform Internet Speed Test</a></li>
 <!--				<li><a href="#utilsAnsTags">Run Ansible by Tag</a></li> -->
 <!--				<li><a href="#utilsResetNetwork">Troubleshoot Networking</a></li> -->
@@ -147,6 +148,10 @@
 					<pre><div id=sysStorage>
 					</div></pre>
 				</div> <!--  End utilsStorage pane -->
+				<div class="tab-pane" id="utilsHwInfo"> <!-- Start utilsHwInfo Pane -->
+					<h2>Hardware Information</h2>
+					<div id="hwInfo"></div>
+				</div> <!--  End utilsHwInfo pane -->
 				<div class="tab-pane" id="utilsSpeedTest"> <!-- Start utilsSpeedTest Pane -->
 					<h2>Internet Speed Test</h2>
 <!--					<p><b>WARNING:</b> The first test retrieves a 10M data file.  The second is more than 100M.  If you have a mobile internet connection this could be costly.</p>

--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -1876,6 +1876,22 @@ function getSysMem()
   return true;
 }
 
+function getHwInfo()
+{
+  sendCmdSrvCmd("GET-HW-INFO", procHwInfo);
+  return true;
+}
+
+function procHwInfo(data)
+{
+  consoleLog(data);
+  var hwInfo = data['hw_info'];
+  var jstr = JSON.stringify(hwInfo, undefined, 2);
+  var html = jstr.replace(/\n/g, "<br>").replace(/[ ]/g, "&nbsp;");
+  $( "#hwInfo" ).html(html);
+  return true;
+}
+
 function procSysMem(data)
 {
   //alert ("in procSysMem");


### PR DESCRIPTION
Adds a "Display Hardware Info" item to the Utilities menu, which runs `lshw -json -quiet -sanitize` and displays the resulting JSON. 

<img width="2124" height="1797" alt="image" src="https://github.com/user-attachments/assets/713ecf9f-96a6-472b-b7a0-29bc3163a5c7" />
