### PR TITLE
Replace Perl call with libcrypt

### DIFF
--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -20,7 +20,7 @@ from systemd import journal
 import pwd, grp
 import time
 from datetime import date, datetime, timedelta
-import threading, subprocess
+import threading, subprocess, ctypes
 import shlex
 import shutil
 import zmq
@@ -3419,10 +3419,16 @@ def read_pw_hash(user):
             break
     return pw_hash
 
+_libcrypt = ctypes.CDLL('libcrypt.so.1')
+_libcrypt.crypt.restype = ctypes.c_char_p
+_libcrypt.crypt.argtypes = [ctypes.c_char_p, ctypes.c_char_p]
+_crypt_lock = threading.Lock()  # prevents concurrent calls from corrupting each other
+
 def calc_passwd_hash(password, existing_hash):
-    # return calculated hash
     try:
-       return subprocess.run(['perl', '-e', f"print crypt('{password}', '{existing_hash}')"], capture_output=True, text=True).stdout
+        with _crypt_lock:
+            result = _libcrypt.crypt(password.encode(), existing_hash.encode())
+            return result.decode() if result else None  
     except:
         return None
 


### PR DESCRIPTION
- Calls `libcrypt.so.1` directly via `ctypes` instead of spawning Perl. The password is passed as raw bytes to the C function.
- Adds a module-level `threading.Lock()` around the `crypt()` call. Without the lock, concurrent AUTHENTICATE requests caused a segfault during testing.

## Libcrypt maintenance

`libcrypt.so.1` is provided by `libxcrypt` (Ubuntu core package). This is unrelated to Python's removed `crypt` stdlib module or the `crypt_r` pypi replacement - we call the C library directly via `ctypes`, bypassing that issue entirely. `libxcrypt` is actively maintained and ships on all modern Ubuntu/Debian systems.

## Tests

- Ran cmdsrv manually
- Confirmed `wrongpass); echo 0 #` returns "User or Password Incorrect" with no server-side execution
- Confirmed legitimate password change succeeds 