### PR TITLE
Fix print() calls in cmdsrv

### DIFF
--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -2462,7 +2462,7 @@ def install_presets(cmd_info):
     zim_cmd_info = cmd_info
     for ref in perma_ref_idx:
         if perma_ref_idx[ref]['id'] in zims_installed:
-            tprint('Skipping already installed ' + ref)
+            log(syslog.LOG_INFO, 'Skipping already installed ' + ref)
             continue # skip already installed zims
         zim_cmd_info['cmd'] ='INST-ZIM'
         zim_cmd_info['cmd_args'] = {'zim_id': perma_ref_idx[ref]['id']}
@@ -2561,7 +2561,7 @@ def pseudo_cmd_handler(cmd_info, check_dup=True):
     if check_dup: # ansible does it's own check
         dup_cmd = next((job_id for job_id, active_cmd_msg in list(active_commands.items()) if active_cmd_msg == cmd_msg), None)
         if dup_cmd != None:
-            tprint('Skipping already running command.')
+            log(syslog.LOG_INFO, 'Skipping already running command.')
             return None
 
     cmd_rowid = insert_command(cmd_msg)
@@ -3286,7 +3286,7 @@ def authenticate (cmd_info):
 
     #print (user, passwd)
     if not auth_calcs(user, passwd):
-        tprint('Bad Password')
+        log(syslog.LOG_WARNING, 'Bad Password')
         return '"INVALID"'
     else:
         return '"VALID"'
@@ -3623,6 +3623,8 @@ def log(level, msg):
    #print level, msg
    #print journal_log.getEffectiveLevel()
    journal_log.log(levels[level], "IIAB-CMDSRV : " + msg)
+   if daemon_mode == False:
+       tprint(msg)
 
 def cmd_success(cmd):
    return (cmd_success_msg(cmd, ""))

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -1537,7 +1537,7 @@ def set_nmcli_connection(cmd, connect_wifi_ssid, connect_wifi_bssid, connect_wif
     psk = wpa_psk(connect_wifi_ssid, connect_wifi_password)
     cmdstr = 'nmcli device wifi connect ' + connect_wifi_bssid + ' password '  + psk
 
-    print(cmdstr)
+    # print(cmdstr)
 
     try:
         rc = adm.subproc_run(cmdstr)
@@ -2462,7 +2462,7 @@ def install_presets(cmd_info):
     zim_cmd_info = cmd_info
     for ref in perma_ref_idx:
         if perma_ref_idx[ref]['id'] in zims_installed:
-            print('Skipping already installed ' + ref)
+            tprint('Skipping already installed ' + ref)
             continue # skip already installed zims
         zim_cmd_info['cmd'] ='INST-ZIM'
         zim_cmd_info['cmd_args'] = {'zim_id': perma_ref_idx[ref]['id']}
@@ -2561,7 +2561,7 @@ def pseudo_cmd_handler(cmd_info, check_dup=True):
     if check_dup: # ansible does it's own check
         dup_cmd = next((job_id for job_id, active_cmd_msg in list(active_commands.items()) if active_cmd_msg == cmd_msg), None)
         if dup_cmd != None:
-            print('Skipping already running command.')
+            tprint('Skipping already running command.')
             return None
 
     cmd_rowid = insert_command(cmd_msg)
@@ -3286,7 +3286,7 @@ def authenticate (cmd_info):
 
     #print (user, passwd)
     if not auth_calcs(user, passwd):
-        print('Bad Password')
+        tprint('Bad Password')
         return '"INVALID"'
     else:
         return '"VALID"'
@@ -3465,7 +3465,7 @@ def get_last_jobs_stat(cmd_info):
     # ToDo add logic to get more, previous results
     # get last_rowid
 
-    print(cmd_info)
+    # print(cmd_info)
     try:
         last_rowid = int(cmd_info['cmd_args'].get('last_rowid'))
     except:


### PR DESCRIPTION
- Comment out `print(cmdstr)` in `set_nmcli_connection()`: was leaking the nmcli command including wifi password in plaintext
- Comment out `print(cmd_info)` in `get_last_jobs_stat()`: prints the entire command info dictionary to the terminal on every call to get_last_jobs_stat(), which gets called frequently for job status updates.
- Convert three legitimate log messages to `tprint()`: "Skipping already installed", "Skipping already running command.", "Bad Password"

Note: `tprint()` is also silent in daemon mode, so these messages do not appear in the journal. "Bad Password" in particular may be worth logging via `log()`?

Tested on: Ubuntu 26.04 LTS, Python 3.14.4, nginx 1.28.3