### PR TITLE
Fix mutable default arg in read_library_xml()

### DIFF
--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -2092,11 +2092,9 @@ def get_zim_stat(cmd_info):
     resp = json.dumps(all_zims)
     return (resp)
 
-def read_library_xml(lib_xml_file, kiwix_exclude_attr=None):
-    if kiwix_exclude_attr is None:
-        kiwix_exclude_attr = [""]
-    kiwix_exclude_attr.append("id") # don't include id
-    kiwix_exclude_attr.append("favicon") # don't include large favicon
+def read_library_xml(lib_xml_file, kiwix_exclude_attr=["favicon"]):
+    excluded_attr = {'id'} # use a set and never include the key
+    excluded_attr.update(kiwix_exclude_attr)
     zims_installed = {}
     try:
         tree = ET.parse(lib_xml_file)
@@ -2108,7 +2106,7 @@ def read_library_xml(lib_xml_file, kiwix_exclude_attr=None):
             if 'id' in child.attrib:
                 id = child.attrib['id']
                 for attr in child.attrib:
-                    if attr not in kiwix_exclude_attr:
+                    if attr not in excluded_attr:
                         attributes[attr] = child.attrib[attr] # copy if not id or in exclusion list
                 zims_installed[id] = attributes
     except IOError:

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -2092,7 +2092,9 @@ def get_zim_stat(cmd_info):
     resp = json.dumps(all_zims)
     return (resp)
 
-def read_library_xml(lib_xml_file, kiwix_exclude_attr=[""]):
+def read_library_xml(lib_xml_file, kiwix_exclude_attr=None):
+    if kiwix_exclude_attr is None:
+        kiwix_exclude_attr = [""]
     kiwix_exclude_attr.append("id") # don't include id
     kiwix_exclude_attr.append("favicon") # don't include large favicon
     zims_installed = {}

--- a/roles/cmdsrv/templates/scripts/upgrade-zims.py
+++ b/roles/cmdsrv/templates/scripts/upgrade-zims.py
@@ -192,9 +192,9 @@ def read_kiwix_catalog(KIWIX_CAT):
     zims_catalog = download['zims']
     return zims_catalog
 
-def read_library_xml(lib_xml_file, kiwix_exclude_attr=[""]): # duplicated from iiab-cmdsrv
-    kiwix_exclude_attr.append("id") # don't include id
-    kiwix_exclude_attr.append("favicon") # don't include large favicon
+def read_library_xml(lib_xml_file, kiwix_exclude_attr=["favicon"]): # duplicated from iiab-cmdsrv
+    excluded_attr = {'id'} # use a set and never include the key
+    excluded_attr.update(kiwix_exclude_attr)
     zims_installed = {}
     path_to_id_map = {}
     try:
@@ -208,7 +208,7 @@ def read_library_xml(lib_xml_file, kiwix_exclude_attr=[""]): # duplicated from i
                   print ("xml record missing Book Id")
             id = child.attrib['id']
             for attr in child.attrib:
-                if attr not in kiwix_exclude_attr:
+                if attr not in excluded_attr:
                     attributes[attr] = child.attrib[attr] # copy if not id or in exclusion list
             zims_installed[id] = attributes
             path_to_id_map[child.attrib['path']] = id


### PR DESCRIPTION
Fix item 5 from the v1.0 release checklist (#650).

read_library_xml() used a list as a default arg for kiwix_exclude_attr. Default arg values are evaluated once at function definition time, so the same list object was shared across all calls. Each call appended "id" and "favicon" to it, causing the list to grow every call. Fixed by using None as the default and initializing a fresh list inside the function when no arg is passed.

- Confirmed bug with a test script calling the function twice and inspecting `__defaults__`

```
--- BEFORE FIX ---
kiwix_exclude_attr default before any calls: ([''],)
kiwix_exclude_attr default after call 1:     (['', 'id', 'favicon'],)
kiwix_exclude_attr default after call 2:     (['', 'id', 'favicon', 'id', 'favicon'],)

--- AFTER FIX ---
kiwix_exclude_attr default before any calls: (None,)
kiwix_exclude_attr default after call 1:     (None,)
kiwix_exclude_attr default after call 2:     (None,)
```

- Confirmed "Get ZIM Files from Kiwix" catalog loads correctly after fix

Tested on: Ubuntu 26.04, Python 3.14

