### PR TITLE
Add initial sync server content workflow

### DIFF
--- a/docs/6.Sync-Server-Content.md
+++ b/docs/6.Sync-Server-Content.md
@@ -1,0 +1,119 @@
+# Sync Server Content
+
+## Manual Inventory Check
+
+This note records the first small test for Sync Server Content: one IIAB server
+publishes a simple content list, and another IIAB server reads it over the
+network. Nothing here depends on the Admin Console UI, Avahi discovery, rsync
+jobs, or automatic inventory generation yet.
+
+## What We Tested
+
+The source VM is `iiab-source`; the destination VM is `iiab-dest`.
+
+The test file lives on the source server at:
+
+```bash
+/library/www/html/common/assets/iiab-sync/content.json
+```
+
+From another server, it should be reachable at:
+
+```bash
+http://<source-ip>/common/assets/iiab-sync/content.json
+```
+
+For the VM test, `iiab-dest` successfully fetched and parsed the inventory from
+`iiab-source`.
+
+## Inventory Shape
+
+For now, the inventory is a small JSON file with three useful parts:
+
+- `server`: basic information about the source server.
+- `zims`: ZIM files available on the source server.
+- `modules`: static modules available on the source server.
+
+Example:
+
+```json
+{
+  "schema_version": 1,
+  "server": {
+    "hostname": "iiab-source",
+    "role": "source",
+    "base_url": "http://<source-ip>",
+    "generated_by": "manual-inventory-test"
+  },
+  "zims": [
+    {
+      "id": "test-zim",
+      "title": "Test ZIM",
+      "file_ref": "test",
+      "path": "/library/zims/content/test.zim",
+      "size_k": 1024,
+      "language": "eng"
+    }
+  ],
+  "modules": [
+    {
+      "moddir": "en-test-module",
+      "title": "English Test Module",
+      "description": "Small static module used for sync testing.",
+      "lang": "en",
+      "ksize": 1024,
+      "menu_item_name": "en-test-module",
+      "intended_use": "html",
+      "source": "iiab-meta"
+    }
+  ]
+}
+```
+
+This is only a draft format. It is good enough for the first backend command,
+but the exact fields can still change once inventory generation is automated.
+
+## Commands Used
+
+On `iiab-source`:
+
+```bash
+sudo mkdir -p /library/www/html/common/assets/iiab-sync
+```
+
+From the development machine:
+
+```bash
+scp test-files/sync-content.json garba@<source-ip>:/tmp/content.json
+ssh -t garba@<source-ip> 'sudo cp /tmp/content.json /library/www/html/common/assets/iiab-sync/content.json && sudo chmod 644 /library/www/html/common/assets/iiab-sync/content.json'
+```
+
+Verify on `iiab-source`:
+
+```bash
+python3 -m json.tool /library/www/html/common/assets/iiab-sync/content.json
+curl -I http://localhost/common/assets/iiab-sync/content.json
+```
+
+Fetch from `iiab-dest`:
+
+```bash
+curl -s http://<source-ip>/common/assets/iiab-sync/content.json -o /tmp/source-content.json
+python3 -m json.tool /tmp/source-content.json
+```
+
+## Result
+
+The manual inventory file was served by `iiab-source` and fetched successfully
+from `iiab-dest`. This confirms that the next backend step can start with a
+simple command that fetches `content.json` by source IP address.
+
+## Questions To Settle
+
+- Should the inventory be generated on demand, during install, or after content
+  changes?
+- Should non-catalog modules with bad or missing `.iiab-meta` be hidden, or
+  shown as invalid?
+- Should clients use `base_url`, or derive the URL from the selected source
+  server?
+- Should ZIMs be identified by Kiwix library ID, file reference, or both?

--- a/docs/6.Sync-Server-Content.md
+++ b/docs/6.Sync-Server-Content.md
@@ -1,119 +1,243 @@
 # Sync Server Content
 
-## Manual Inventory Check
+This note documents the current Sync Server Content implementation. The feature
+lets one IIAB server pull selected content from another IIAB server over the
+network. It follows the existing Manage Content workflow, but uses a remote
+IIAB server as the source instead of USB storage.
 
-This note records the first small test for Sync Server Content: one IIAB server
-publishes a simple content list, and another IIAB server reads it over the
-network. Nothing here depends on the Admin Console UI, Avahi discovery, rsync
-jobs, or automatic inventory generation yet.
+The implementation is intentionally narrow at this stage: manual, on-demand,
+and pull-only.
 
-## What We Tested
+## What Is Included
 
-The source VM is `iiab-source`; the destination VM is `iiab-dest`.
+- ZIM inventory and transfer
+- ZIM index transfer when an index is available
+- Static module inventory and transfer
+- Custom static modules with `.iiab-meta`
+- Manual source IP entry
+- Avahi discovery using `_iiab-sync._tcp`
+- Admin Console UI for loading remote content and scheduling sync jobs
 
-The test file lives on the source server at:
+## What Is Not Included Yet
 
-```bash
-/library/www/html/common/assets/iiab-sync/content.json
+- Scheduled or automatic sync
+- Push sync
+- Different source and destination directory layouts
+- Calibre Web or other database-backed content
+- General application sync
+- Nmap discovery fallback
+- Disk-space preflight checks
+
+## Basic Flow
+
+A source server:
+
+- advertises `_iiab-sync._tcp` through Avahi
+- generates `/library/www/html/common/assets/iiab-sync/content.json`
+- serves that inventory over HTTP
+- allows selected files to be pulled with `rsync` over SSH
+
+A destination server:
+
+- discovers source servers with `GET-SYNC-SERVERS`
+- fetches source inventory with `GET-SYNC-CONTENT`
+- displays remote ZIMs and modules in Manage Content
+- schedules `SYNC-ZIMS` and `SYNC-OER2GO-MOD` jobs
+
+The source never pushes content. The destination initiates the sync.
+
+## Admin Console
+
+The UI is under:
+
+```text
+Install Content -> Manage Content -> Content on Server
 ```
 
-From another server, it should be reachable at:
+The administrator can click `Discover Servers` or enter a source IP manually.
+When discovery returns an SSH user, selecting the server fills both:
+
+- `Source Server`
+- `Source SSH User`
+
+The default advertised SSH user is currently `iiab-admin`. The field remains
+editable for servers that use another account.
+
+## CMDSRV Commands
+
+Discover sync sources:
 
 ```bash
-http://<source-ip>/common/assets/iiab-sync/content.json
+sudo iiab-cmdsrv-ctl 'GET-SYNC-SERVERS'
 ```
 
-For the VM test, `iiab-dest` successfully fetched and parsed the inventory from
-`iiab-source`.
+Generate local inventory:
 
-## Inventory Shape
+```bash
+sudo iiab-cmdsrv-ctl 'MAKE-SYNC-CONTENT'
+```
 
-For now, the inventory is a small JSON file with three useful parts:
+Fetch source inventory:
 
-- `server`: basic information about the source server.
-- `zims`: ZIM files available on the source server.
-- `modules`: static modules available on the source server.
+```bash
+sudo iiab-cmdsrv-ctl 'GET-SYNC-CONTENT {"source_host":"192.168.1.50"}'
+```
+
+Pull one ZIM:
+
+```bash
+sudo iiab-cmdsrv-ctl 'SYNC-ZIMS {"source_host":"192.168.1.50","source_user":"iiab-admin","file_ref":"test"}'
+```
+
+Pull one module:
+
+```bash
+sudo iiab-cmdsrv-ctl 'SYNC-OER2GO-MOD {"source_host":"192.168.1.50","source_user":"iiab-admin","moddir":"en-test-module"}'
+```
+
+## Custom Modules
+
+Catalog modules use OER2Go metadata. Custom static modules need a `.iiab-meta`
+file in the top-level module directory:
+
+```text
+/library/www/html/modules/<moddir>/.iiab-meta
+```
 
 Example:
 
 ```json
 {
-  "schema_version": 1,
-  "server": {
-    "hostname": "iiab-source",
-    "role": "source",
-    "base_url": "http://<source-ip>",
-    "generated_by": "manual-inventory-test"
-  },
-  "zims": [
-    {
-      "id": "test-zim",
-      "title": "Test ZIM",
-      "file_ref": "test",
-      "path": "/library/zims/content/test.zim",
-      "size_k": 1024,
-      "language": "eng"
-    }
-  ],
-  "modules": [
-    {
-      "moddir": "en-test-module",
-      "title": "English Test Module",
-      "description": "Small static module used for sync testing.",
-      "lang": "en",
-      "ksize": 1024,
-      "menu_item_name": "en-test-module",
-      "intended_use": "html",
-      "source": "iiab-meta"
-    }
-  ]
+  "moddir": "en-test-eldp",
+  "title": "ELDP Test Module",
+  "description": "Static custom module for IIAB sync testing.",
+  "lang": "eng",
+  "ksize": 1024,
+  "menu_item_name": "en-test-eldp",
+  "intended_use": "html"
 }
 ```
 
-This is only a draft format. It is good enough for the first backend command,
-but the exact fields can still change once inventory generation is automated.
+Required fields:
 
-## Commands Used
+- `moddir`
+- `title`
+- `description`
+- `lang`
+- `ksize`
+- `menu_item_name`
+- `intended_use`
 
-On `iiab-source`:
+`moddir` must match the module folder name. `ksize` must be an integer number
+of kilobytes. A quick way to estimate it is:
 
 ```bash
-sudo mkdir -p /library/www/html/common/assets/iiab-sync
+du -sk /library/www/html/modules/<moddir>
 ```
 
-From the development machine:
+After creating or editing `.iiab-meta`, regenerate the inventory:
 
 ```bash
-scp test-files/sync-content.json garba@<source-ip>:/tmp/content.json
-ssh -t garba@<source-ip> 'sudo cp /tmp/content.json /library/www/html/common/assets/iiab-sync/content.json && sudo chmod 644 /library/www/html/common/assets/iiab-sync/content.json'
+sudo iiab-cmdsrv-ctl 'MAKE-SYNC-CONTENT'
 ```
 
-Verify on `iiab-source`:
+Valid custom modules appear in `modules`. Missing or invalid metadata is listed
+under `invalid_modules`.
+
+## SSH Requirement
+
+Inventory loading uses HTTP. Actual transfer uses `rsync` over SSH.
+
+The destination backend usually runs as root, but it can SSH into the source as
+the configured source user:
+
+```text
+root@destination -> iiab-admin@source
+```
+
+Before transfer, this must work from the destination server without a password
+prompt:
 
 ```bash
+sudo ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5 iiab-admin@<source-ip> true
+```
+
+If that test fails, `SYNC-ZIMS` and `SYNC-OER2GO-MOD` will fail before starting
+the rsync job.
+
+## Testing Notes
+
+Source inventory:
+
+```bash
+sudo iiab-cmdsrv-ctl 'MAKE-SYNC-CONTENT'
 python3 -m json.tool /library/www/html/common/assets/iiab-sync/content.json
-curl -I http://localhost/common/assets/iiab-sync/content.json
+curl -s http://<source-ip>/common/assets/iiab-sync/content.json | python3 -m json.tool
 ```
 
-Fetch from `iiab-dest`:
+Discovery from destination:
 
 ```bash
-curl -s http://<source-ip>/common/assets/iiab-sync/content.json -o /tmp/source-content.json
-python3 -m json.tool /tmp/source-content.json
+sudo iiab-cmdsrv-ctl 'GET-SYNC-SERVERS'
 ```
 
-## Result
+Inventory fetch from destination:
 
-The manual inventory file was served by `iiab-source` and fetched successfully
-from `iiab-dest`. This confirms that the next backend step can start with a
-simple command that fetches `content.json` by source IP address.
+```bash
+sudo iiab-cmdsrv-ctl 'GET-SYNC-CONTENT {"source_host":"<source-ip>"}'
+```
 
-## Questions To Settle
+UI test:
 
-- Should the inventory be generated on demand, during install, or after content
-  changes?
-- Should non-catalog modules with bad or missing `.iiab-meta` be hidden, or
-  shown as invalid?
-- Should clients use `base_url`, or derive the URL from the selected source
-  server?
-- Should ZIMs be identified by Kiwix library ID, file reference, or both?
+- open `Install Content -> Manage Content -> Content on Server`
+- click `Discover Servers`
+- select a source server
+- confirm source IP and SSH user are filled
+- click `Load Content`
+- confirm remote ZIMs and modules are listed
+
+Transfer test:
+
+- confirm passwordless SSH from destination root to the source user
+- sync one small module
+- sync one small ZIM
+- check the existing job status UI for completion or errors
+
+## Known Limitations
+
+- Manual and on-demand only.
+- Pull-only.
+- ZIMs and static modules only.
+- Calibre Web and other database-backed content are out of scope for this PR.
+- Source and destination directory structures are expected to match.
+- SSH key setup is required for transfer.
+- Avahi discovery is implemented; nmap fallback is not.
+- Manual IP entry remains necessary on networks where mDNS does not work.
+- Disk-space checks are not implemented yet.
+
+## Draft PR Summary
+
+This PR adds an initial Sync Server Content workflow to Admin Console. It allows
+one IIAB server to discover another IIAB server, load its ZIM/module inventory,
+and pull selected content on demand.
+
+Implemented:
+
+- Avahi `_iiab-sync._tcp` advertisement
+- `GET-SYNC-SERVERS`
+- `MAKE-SYNC-CONTENT`
+- `GET-SYNC-CONTENT`
+- `SYNC-ZIMS`
+- `SYNC-OER2GO-MOD`
+- Manage Content UI for remote content
+- `.iiab-meta` support for custom static modules
+- pull-only rsync transfer from destination to source
+
+Out of scope for this PR:
+
+- Calibre Web/database-backed content
+- automated sync
+- push sync
+- nmap fallback
+- syncing arbitrary applications
+

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -31,6 +31,7 @@ import yaml
 import configparser
 import re
 import urllib.request, urllib.error, urllib.parse
+import ipaddress
 import string
 import mimetypes
 import cracklib
@@ -105,6 +106,7 @@ vector_map_tiles_path = None
 osm_version = None
 modules_dir = None
 small_device_size = 525000 # bigger than anticipated boot partition
+sync_content_inventory_path = "/common/assets/iiab-sync/content.json"
 js_menu_dir = None
 tailscale_login_url = 'https://controlplane.tailscale.com'
 tailscale_iiab_login_url = 'https://iiab.net'
@@ -739,6 +741,7 @@ def cmd_handler(cmd_msg):
         "GET-SPACE-AVAIL": {"funct": get_space_avail, "inet_req": False},
         "GET-STORAGE-INFO": {"funct": get_storage_info_lite, "inet_req": False},
         "GET-EXTDEV-INFO": {"funct": get_external_device_info, "inet_req": False},
+        "GET-SYNC-CONTENT": {"funct": get_sync_content, "inet_req": False},
         "GET-REM-DEV-LIST": {"funct": get_rem_dev_list, "inet_req": False},
         "GET-SYSTEM-INFO": {"funct": get_system_info, "inet_req": False},
         "GET-NETWORK-INFO": {"funct": get_network_info, "inet_req": False},
@@ -1212,6 +1215,61 @@ def get_storage_info_lite(cmd_info):
     outp = subproc_check_output(cmd_args)
     json_outp = json_array("system_fs", outp)
     return (json_outp)
+
+def validate_sync_source_host(source_host):
+    if not isinstance(source_host, str):
+        return None
+
+    source_host = source_host.strip()
+    if len(source_host) == 0 or len(source_host) > 253:
+        return None
+
+    try:
+        ip_addr = ipaddress.ip_address(source_host)
+        if ip_addr.version == 6:
+            return "[" + source_host + "]"
+        return source_host
+    except ValueError:
+        pass
+
+    hostname_re = re.compile(r"^(?=.{1,253}$)([A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)*[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$")
+    if hostname_re.match(source_host):
+        return source_host
+
+    return None
+
+def get_sync_content(cmd_info):
+    try:
+        source_host = cmd_info['cmd_args']['source_host']
+    except:
+        return cmd_malformed(cmd_info['cmd'])
+
+    safe_source_host = validate_sync_source_host(source_host)
+    if safe_source_host == None:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Invalid source host')
+
+    inventory_url = "http://" + safe_source_host + sync_content_inventory_path
+
+    try:
+        with urllib.request.urlopen(inventory_url, timeout=10) as response:
+            if response.status != 200:
+                return cmd_error(cmd=cmd_info['cmd'], msg='Unable to fetch sync content inventory')
+            inventory_bytes = response.read()
+    except urllib.error.HTTPError as exc:
+        if exc.code == 404:
+            return cmd_error(cmd=cmd_info['cmd'], msg='Sync content inventory not found')
+        return cmd_error(cmd=cmd_info['cmd'], msg='Unable to fetch sync content inventory')
+    except urllib.error.URLError:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Unable to reach sync source server')
+    except socket.timeout:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Timed out contacting sync source server')
+
+    try:
+        inventory = json.loads(inventory_bytes.decode('utf-8'))
+    except:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Invalid sync content inventory JSON')
+
+    return json.dumps(inventory)
 
 def get_external_device_info(cmd_info):
     extdev_info = {}

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -780,6 +780,7 @@ def cmd_handler(cmd_msg):
         "GET-OER2GO-CAT": {"funct": get_oer2go_catalog, "inet_req": True},
         "INST-OER2GO-MOD": {"funct": install_oer2go_mod, "inet_req": True},
         "COPY-OER2GO-MOD": {"funct": copy_oer2go_mod, "inet_req": False},
+        "SYNC-OER2GO-MOD": {"funct": sync_oer2go_mod, "inet_req": False},
         "GET-OER2GO-STAT": {"funct": get_oer2go_stat, "inet_req": False},
         "GET-RACHEL-STAT": {"funct": get_rachel_stat, "inet_req": False},
         "INST-RACHEL": {"funct": install_rachel, "inet_req": True},
@@ -3150,6 +3151,66 @@ def copy_oer2go_mod(cmd_info):
         job_id = request_one_job(cmd_info, job_command, 1, -1, "Y")
         job_command = "scripts/oer2go_install_move.sh " + file_ref
         resp = request_job(cmd_info=cmd_info, job_command=job_command, cmd_step_no=2, depend_on_job_id=job_id, has_dependent="N")
+    return resp
+
+def validate_sync_module_id(moddir):
+    if not isinstance(moddir, str):
+        return None
+    moddir = moddir.strip()
+    if re.match(r"^[A-Za-z0-9._-]+$", moddir):
+        return moddir
+    return None
+
+def validate_sync_source_user(source_user):
+    if source_user == None:
+        return None
+    if not isinstance(source_user, str):
+        return None
+    source_user = source_user.strip()
+    if re.match(r"^[A-Za-z0-9._-]+$", source_user):
+        return source_user
+    return None
+
+def sync_oer2go_mod(cmd_info):
+    try:
+        source_host = cmd_info['cmd_args']['source_host']
+        moddir = cmd_info['cmd_args']['moddir']
+    except:
+        return cmd_malformed(cmd_info['cmd'])
+
+    safe_source_host = validate_sync_source_host(source_host)
+    safe_moddir = validate_sync_module_id(moddir)
+    source_user = cmd_info['cmd_args'].get('source_user')
+    safe_source_user = validate_sync_source_user(source_user)
+
+    if safe_source_host == None:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Invalid source host')
+    if safe_moddir == None:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Invalid module id')
+    if source_user != None and safe_source_user == None:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Invalid source user')
+
+    refresh_oer2go_installed()
+    if safe_moddir in oer2go_installed:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Module already installed')
+
+    try:
+        os.makedirs(rachel_working_dir, exist_ok=True)
+    except:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Error creating module working directory')
+
+    remote_host = safe_source_host
+    if safe_source_user != None:
+        remote_host = safe_source_user + "@" + safe_source_host
+
+    remote_source = remote_host + ":" + modules_dir + safe_moddir
+    job_command = "/usr/bin/rsync -rPt --size-only -e " + shlex.quote("ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new")
+    job_command += " " + shlex.quote(remote_source)
+    job_command += " " + shlex.quote(rachel_working_dir)
+
+    job_id = request_one_job(cmd_info, job_command, 1, -1, "Y")
+    job_command = "scripts/oer2go_install_move.sh " + shlex.quote(safe_moddir)
+    resp = request_job(cmd_info=cmd_info, job_command=job_command, cmd_step_no=2, depend_on_job_id=job_id, has_dependent="N")
     return resp
 
 def get_oer2go_stat(cmd_info):

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -1288,6 +1288,18 @@ def is_sync_discovery_address_usable(address):
     except ValueError:
         return True
 
+def parse_avahi_txt_records(parts):
+    txt_records = {}
+
+    for value in parts[9:]:
+        value = unescape_avahi_field(value).strip('"')
+        if "=" not in value:
+            continue
+        key, record_value = value.split("=", 1)
+        txt_records[key] = record_value
+
+    return txt_records
+
 def parse_avahi_sync_servers(outp):
     servers = []
     seen = set()
@@ -1308,6 +1320,7 @@ def parse_avahi_sync_servers(outp):
         host = parts[6].rstrip(".")
         address = parts[7]
         port = parts[8]
+        txt_records = parse_avahi_txt_records(parts)
 
         if service_type != "_iiab-sync._tcp":
             continue
@@ -1321,12 +1334,19 @@ def parse_avahi_sync_servers(outp):
             continue
         seen.add(server_key)
 
-        servers.append({
+        server = {
             "service_name": service_name,
             "host": host,
             "address": address,
             "port": port
-        })
+        }
+
+        if "path" in txt_records:
+            server["path"] = txt_records["path"]
+        if "ssh_user" in txt_records:
+            server["ssh_user"] = txt_records["ssh_user"]
+
+        servers.append(server)
 
     return servers
 

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -749,6 +749,7 @@ def cmd_handler(cmd_msg):
         "GET-SPACE-AVAIL": {"funct": get_space_avail, "inet_req": False},
         "GET-STORAGE-INFO": {"funct": get_storage_info_lite, "inet_req": False},
         "GET-EXTDEV-INFO": {"funct": get_external_device_info, "inet_req": False},
+        "GET-SYNC-SERVERS": {"funct": get_sync_servers, "inet_req": False},
         "GET-SYNC-CONTENT": {"funct": get_sync_content, "inet_req": False},
         "MAKE-SYNC-CONTENT": {"funct": make_sync_content, "inet_req": False},
         "GET-REM-DEV-LIST": {"funct": get_rem_dev_list, "inet_req": False},
@@ -1267,6 +1268,88 @@ def validate_sync_content_inventory(inventory):
             return False
 
     return True
+
+def get_local_ip_addresses():
+    try:
+        outp = subproc_check_output(["/bin/hostname", "-I"])
+        return set(outp.split())
+    except:
+        return set()
+
+def unescape_avahi_field(value):
+    def replace_match(match):
+        return chr(int(match.group(1), 10))
+    return re.sub(r"\\([0-7]{3})", replace_match, value)
+
+def is_sync_discovery_address_usable(address):
+    try:
+        ip_addr = ipaddress.ip_address(address)
+        return not ip_addr.is_loopback and not ip_addr.is_link_local
+    except ValueError:
+        return True
+
+def parse_avahi_sync_servers(outp):
+    servers = []
+    seen = set()
+    local_hostname = socket.gethostname()
+    local_names = {local_hostname, local_hostname + ".local"}
+    local_ips = get_local_ip_addresses()
+
+    for line in outp.splitlines():
+        if not line.startswith("="):
+            continue
+
+        parts = line.split(";")
+        if len(parts) < 9:
+            continue
+
+        service_name = unescape_avahi_field(parts[3])
+        service_type = parts[4]
+        host = parts[6].rstrip(".")
+        address = parts[7]
+        port = parts[8]
+
+        if service_type != "_iiab-sync._tcp":
+            continue
+        if not is_sync_discovery_address_usable(address):
+            continue
+        if host in local_names or address in local_ips:
+            continue
+
+        server_key = address + ":" + port
+        if server_key in seen:
+            continue
+        seen.add(server_key)
+
+        servers.append({
+            "service_name": service_name,
+            "host": host,
+            "address": address,
+            "port": port
+        })
+
+    return servers
+
+def get_sync_servers(cmd_info):
+    try:
+        result = subprocess.run(
+            ["/usr/bin/avahi-browse", "-rtp", "_iiab-sync._tcp"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=8
+        )
+    except FileNotFoundError:
+        return cmd_error(cmd=cmd_info['cmd'], msg='avahi-browse is not installed')
+    except subprocess.TimeoutExpired:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Timed out discovering sync servers')
+    except:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Unable to discover sync servers')
+
+    if result.returncode != 0 and result.stdout.strip() == "":
+        return cmd_error(cmd=cmd_info['cmd'], msg='Unable to discover sync servers')
+
+    return json.dumps({"servers": parse_avahi_sync_servers(result.stdout)})
 
 def get_sync_content(cmd_info):
     try:

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -107,6 +107,7 @@ osm_version = None
 modules_dir = None
 small_device_size = 525000 # bigger than anticipated boot partition
 sync_content_inventory_path = "/common/assets/iiab-sync/content.json"
+sync_module_meta_required_fields = ["moddir", "title", "description", "lang", "ksize", "menu_item_name", "intended_use"]
 js_menu_dir = None
 tailscale_login_url = 'https://controlplane.tailscale.com'
 tailscale_iiab_login_url = 'https://iiab.net'
@@ -1375,13 +1376,13 @@ def build_sync_module_inventory():
         try:
             with open(meta_path, "r") as meta_file:
                 module = json.load(meta_file)
-            if not isinstance(module, dict):
+            invalid_reason = validate_sync_module_meta(module, moddir)
+            if invalid_reason != None:
                 invalid_modules.append({
                     "moddir": moddir,
-                    "reason": "invalid .iiab-meta"
+                    "reason": invalid_reason
                 })
                 continue
-            module["moddir"] = module.get("moddir", moddir)
             module["source"] = "iiab-meta"
             modules.append(module)
         except:
@@ -1391,6 +1392,30 @@ def build_sync_module_inventory():
             })
 
     return modules, invalid_modules
+
+def validate_sync_module_meta(module, moddir):
+    if not isinstance(module, dict):
+        return "invalid .iiab-meta"
+
+    missing_fields = []
+    for field in sync_module_meta_required_fields:
+        if field not in module:
+            missing_fields.append(field)
+        elif isinstance(module[field], str) and module[field].strip() == "":
+            missing_fields.append(field)
+
+    if len(missing_fields) > 0:
+        return "missing .iiab-meta fields: " + ", ".join(missing_fields)
+
+    if module["moddir"] != moddir:
+        return ".iiab-meta moddir does not match module directory"
+
+    try:
+        int(module["ksize"])
+    except:
+        return ".iiab-meta ksize must be an integer"
+
+    return None
 
 def get_external_device_info(cmd_info):
     extdev_info = {}

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -495,12 +495,16 @@ def add_wip(job_info):
 
     cmd = job_info['cmd']
 
-    if cmd in {"INST-ZIMS", "COPY-ZIMS"}:
-        zim_id = job_info['cmd_args']['zim_id']
+    if cmd in {"INST-ZIMS", "COPY-ZIMS", "SYNC-ZIMS"}:
+        zim_id = job_info['cmd_args'].get('zim_id', job_info['cmd_args'].get('file_ref'))
         if cmd == "INST-ZIMS":
             action = "DOWNLOAD"
             dest = "internal"
             source = "kiwix"
+        elif cmd == "SYNC-ZIMS":
+            action = "IMPORT"
+            dest = "internal"
+            source = "server"
         else:
             dest = job_info['cmd_args']['dest']
             source = job_info['cmd_args']['source']
@@ -510,11 +514,14 @@ def add_wip(job_info):
                 action = "EXPORT"
         zims_wip[zim_id] = {"cmd":cmd, "action":action, "dest":dest, "source":source}
 
-    elif cmd in {"INST-OER2GO-MOD", "COPY-OER2GO-MOD"}:
+    elif cmd in {"INST-OER2GO-MOD", "COPY-OER2GO-MOD", "SYNC-OER2GO-MOD"}:
         moddir = job_info['cmd_args']['moddir']
         if cmd == "INST-OER2GO-MOD":
             action = "DOWNLOAD"
             source = "oer2go"
+        elif cmd == "SYNC-OER2GO-MOD":
+            action = "IMPORT"
+            source = "server"
         else:
             dest = job_info['cmd_args']['dest']
             source = job_info['cmd_args']['source']
@@ -543,9 +550,9 @@ def remove_wip(job_info):
     #print job_info
     #print "in remove_wip"
 
-    if job_info['cmd'] in ["INST-ZIMS", "COPY-ZIMS"]:
-        zims_wip.pop(job_info['cmd_args']['zim_id'], None)
-    elif job_info['cmd'] in ["INST-OER2GO-MOD", "COPY-OER2GO-MOD"]:
+    if job_info['cmd'] in ["INST-ZIMS", "COPY-ZIMS", "SYNC-ZIMS"]:
+        zims_wip.pop(job_info['cmd_args'].get('zim_id', job_info['cmd_args'].get('file_ref')), None)
+    elif job_info['cmd'] in ["INST-OER2GO-MOD", "COPY-OER2GO-MOD", "SYNC-OER2GO-MOD"]:
         oer2go_wip.pop(job_info['cmd_args']['moddir'], None)
     elif job_info['cmd'] in {"INST-OSM-VECT-SET"}:
         maps_wip.pop(job_info['cmd_args']['osm_vect_id'], None)
@@ -3172,6 +3179,22 @@ def validate_sync_source_user(source_user):
         return source_user
     return None
 
+def get_sync_remote_host(source_host, source_user=None):
+    if source_user != None:
+        return source_user + "@" + source_host
+    return source_host
+
+def get_sync_ssh_command():
+    return "ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new -o ConnectTimeout=5"
+
+def check_sync_ssh_access(remote_host):
+    ssh_args = shlex.split(get_sync_ssh_command()) + [remote_host, "true"]
+    try:
+        result = subprocess.run(ssh_args, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=8)
+        return result.returncode == 0
+    except:
+        return False
+
 def validate_sync_zim_file_ref(file_ref):
     if not isinstance(file_ref, str):
         return None
@@ -3182,6 +3205,9 @@ def validate_sync_zim_file_ref(file_ref):
 
 def sync_zim_content_exists(file_ref):
     return len(glob(zim_content_dir + file_ref + ".zim*")) > 0
+
+def sync_module_content_exists(moddir):
+    return os.path.isdir(os.path.join(modules_dir, moddir))
 
 def sync_zim_installed(file_ref, zim_id=None):
     installed_zims = read_library_xml(zim_dir + "/library.xml")
@@ -3231,11 +3257,11 @@ def sync_zims(cmd_info):
     except:
         return cmd_error(cmd=cmd_info['cmd'], msg='Error creating ZIM working directory')
 
-    remote_host = safe_source_host
-    if safe_source_user != None:
-        remote_host = safe_source_user + "@" + safe_source_host
+    remote_host = get_sync_remote_host(safe_source_host, safe_source_user)
+    if not check_sync_ssh_access(remote_host):
+        return cmd_error(cmd=cmd_info['cmd'], msg='Unable to connect to sync source over SSH')
 
-    ssh_command = shlex.quote("ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new")
+    ssh_command = shlex.quote(get_sync_ssh_command())
     remote_zim_source = remote_host + ":" + zim_content_dir + safe_file_ref + ".zim*"
     job_command = "/usr/bin/rsync -rPt --size-only -e " + ssh_command
     job_command += " " + shlex.quote(remote_zim_source)
@@ -3272,7 +3298,7 @@ def sync_oer2go_mod(cmd_info):
         return cmd_error(cmd=cmd_info['cmd'], msg='Invalid source user')
 
     refresh_oer2go_installed()
-    if safe_moddir in oer2go_installed:
+    if safe_moddir in oer2go_installed or sync_module_content_exists(safe_moddir):
         return cmd_error(cmd=cmd_info['cmd'], msg='Module already installed')
 
     try:
@@ -3280,12 +3306,12 @@ def sync_oer2go_mod(cmd_info):
     except:
         return cmd_error(cmd=cmd_info['cmd'], msg='Error creating module working directory')
 
-    remote_host = safe_source_host
-    if safe_source_user != None:
-        remote_host = safe_source_user + "@" + safe_source_host
+    remote_host = get_sync_remote_host(safe_source_host, safe_source_user)
+    if not check_sync_ssh_access(remote_host):
+        return cmd_error(cmd=cmd_info['cmd'], msg='Unable to connect to sync source over SSH')
 
     remote_source = remote_host + ":" + modules_dir + safe_moddir
-    job_command = "/usr/bin/rsync -rPt --size-only -e " + shlex.quote("ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new")
+    job_command = "/usr/bin/rsync -rPt --size-only -e " + shlex.quote(get_sync_ssh_command())
     job_command += " " + shlex.quote(remote_source)
     job_command += " " + shlex.quote(rachel_working_dir)
 

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -775,6 +775,7 @@ def cmd_handler(cmd_msg):
         "GET-UPGRADEABLE-ZIMS": {"funct": get_upgradeable_zims, "inet_req": False},
         "UPGRADE-ZIMS": {"funct": upgrade_zims, "inet_req": True},
         "COPY-ZIMS": {"funct": copy_zims, "inet_req": False},
+        "SYNC-ZIMS": {"funct": sync_zims, "inet_req": False},
         "MAKE-KIWIX-LIB": {"funct": make_kiwix_lib, "inet_req": False}, # runs as job
         "RESTART-KIWIX": {"funct": restart_kiwix, "inet_req": False}, # runs immediately
         "GET-OER2GO-CAT": {"funct": get_oer2go_catalog, "inet_req": True},
@@ -3170,6 +3171,86 @@ def validate_sync_source_user(source_user):
     if re.match(r"^[A-Za-z0-9._-]+$", source_user):
         return source_user
     return None
+
+def validate_sync_zim_file_ref(file_ref):
+    if not isinstance(file_ref, str):
+        return None
+    file_ref = file_ref.strip()
+    if re.match(r"^[A-Za-z0-9._-]+$", file_ref):
+        return file_ref
+    return None
+
+def sync_zim_content_exists(file_ref):
+    return len(glob(zim_content_dir + file_ref + ".zim*")) > 0
+
+def sync_zim_installed(file_ref, zim_id=None):
+    installed_zims = read_library_xml(zim_dir + "/library.xml")
+
+    if zim_id != None and zim_id in installed_zims:
+        return sync_zim_content_exists(file_ref)
+
+    for installed_zim_id in installed_zims:
+        installed_zim = installed_zims[installed_zim_id]
+        if "path" not in installed_zim:
+            continue
+        installed_file = os.path.basename(installed_zim["path"]).split(".zim")[0]
+        if installed_file == file_ref and sync_zim_content_exists(file_ref):
+            return True
+
+    return False
+
+def sync_zims(cmd_info):
+    try:
+        source_host = cmd_info['cmd_args']['source_host']
+        file_ref = cmd_info['cmd_args']['file_ref']
+    except:
+        return cmd_malformed(cmd_info['cmd'])
+
+    safe_source_host = validate_sync_source_host(source_host)
+    safe_file_ref = validate_sync_zim_file_ref(file_ref)
+    source_user = cmd_info['cmd_args'].get('source_user')
+    safe_source_user = validate_sync_source_user(source_user)
+    zim_id = cmd_info['cmd_args'].get('zim_id')
+
+    if safe_source_host == None:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Invalid source host')
+    if safe_file_ref == None:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Invalid ZIM file reference')
+    if source_user != None and safe_source_user == None:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Invalid source user')
+    if zim_id != None and not isinstance(zim_id, str):
+        return cmd_error(cmd=cmd_info['cmd'], msg='Invalid ZIM id')
+
+    if sync_zim_installed(safe_file_ref, zim_id):
+        return cmd_error(cmd=cmd_info['cmd'], msg='ZIM already installed')
+
+    target_dir = zim_working_dir + safe_file_ref + "/data"
+    try:
+        os.makedirs(target_dir + "/content", exist_ok=True)
+        os.makedirs(target_dir + "/index", exist_ok=True)
+    except:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Error creating ZIM working directory')
+
+    remote_host = safe_source_host
+    if safe_source_user != None:
+        remote_host = safe_source_user + "@" + safe_source_host
+
+    ssh_command = shlex.quote("ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new")
+    remote_zim_source = remote_host + ":" + zim_content_dir + safe_file_ref + ".zim*"
+    job_command = "/usr/bin/rsync -rPt --size-only -e " + ssh_command
+    job_command += " " + shlex.quote(remote_zim_source)
+    job_command += " " + shlex.quote(target_dir + "/content")
+    job_id = request_one_job(cmd_info, job_command, 1, -1, "Y")
+
+    remote_index_source = remote_host + ":" + zim_index_dir + safe_file_ref + ".zim.idx"
+    job_command = "/usr/bin/rsync -rPt --size-only --ignore-missing-args -e " + ssh_command
+    job_command += " " + shlex.quote(remote_index_source)
+    job_command += " " + shlex.quote(target_dir + "/index")
+    job_id = request_one_job(cmd_info, job_command, 2, job_id, "Y")
+
+    job_command = "scripts/zim_install_step3.sh " + shlex.quote(safe_file_ref)
+    resp = request_job(cmd_info=cmd_info, job_command=job_command, cmd_step_no=3, depend_on_job_id=job_id, has_dependent="N")
+    return resp
 
 def sync_oer2go_mod(cmd_info):
     try:

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -742,6 +742,7 @@ def cmd_handler(cmd_msg):
         "GET-STORAGE-INFO": {"funct": get_storage_info_lite, "inet_req": False},
         "GET-EXTDEV-INFO": {"funct": get_external_device_info, "inet_req": False},
         "GET-SYNC-CONTENT": {"funct": get_sync_content, "inet_req": False},
+        "MAKE-SYNC-CONTENT": {"funct": make_sync_content, "inet_req": False},
         "GET-REM-DEV-LIST": {"funct": get_rem_dev_list, "inet_req": False},
         "GET-SYSTEM-INFO": {"funct": get_system_info, "inet_req": False},
         "GET-NETWORK-INFO": {"funct": get_network_info, "inet_req": False},
@@ -1292,6 +1293,104 @@ def get_sync_content(cmd_info):
         return cmd_error(cmd=cmd_info['cmd'], msg='Invalid sync content inventory format')
 
     return json.dumps(inventory)
+
+def make_sync_content(cmd_info):
+    modules, invalid_modules = build_sync_module_inventory()
+    inventory = {
+        "schema_version": 1,
+        "server": {
+            "hostname": socket.gethostname(),
+            "base_url": "http://" + socket.gethostname(),
+            "generated_at": datetime.utcnow().isoformat() + "Z",
+            "generated_by": "MAKE-SYNC-CONTENT"
+        },
+        "zims": build_sync_zim_inventory(),
+        "modules": modules,
+        "invalid_modules": invalid_modules
+    }
+
+    if not validate_sync_content_inventory(inventory):
+        return cmd_error(cmd=cmd_info['cmd'], msg='Generated sync content inventory has invalid format')
+
+    inventory_path = doc_root + sync_content_inventory_path
+    inventory_dir = os.path.dirname(inventory_path)
+
+    try:
+        os.makedirs(inventory_dir, exist_ok=True)
+        tmp_inventory_path = inventory_path + ".tmp"
+        with open(tmp_inventory_path, "w") as inventory_file:
+            json.dump(inventory, inventory_file, indent=2)
+        shutil.move(tmp_inventory_path, inventory_path)
+    except:
+        return cmd_error(cmd=cmd_info['cmd'], msg='Unable to write sync content inventory')
+
+    return json.dumps(inventory)
+
+def build_sync_zim_inventory():
+    zims = []
+    lib_xml_file = zim_dir + "/library.xml"
+    installed_zims = read_library_xml(lib_xml_file)
+
+    for zim_id in sorted(installed_zims):
+        zim = dict(installed_zims[zim_id])
+        zim["id"] = zim_id
+
+        if "path" in zim:
+            zim_file = os.path.basename(zim["path"])
+            zim["file_ref"] = zim_file.split(".zim")[0]
+
+        if "size" in zim:
+            try:
+                zim["size_k"] = int(zim["size"])
+            except:
+                pass
+
+        zims.append(zim)
+
+    return zims
+
+def build_sync_module_inventory():
+    modules = []
+    invalid_modules = []
+    dirlist = glob(modules_dir + "/*/")
+
+    for modpath in sorted(dirlist):
+        moddir = modpath.split('/')[-2]
+
+        if moddir in oer2go_catalog:
+            module = dict(oer2go_catalog[moddir])
+            module["moddir"] = moddir
+            module["source"] = "oer2go-catalog"
+            modules.append(module)
+            continue
+
+        meta_path = os.path.join(modpath, ".iiab-meta")
+        if not os.path.isfile(meta_path):
+            invalid_modules.append({
+                "moddir": moddir,
+                "reason": "missing .iiab-meta"
+            })
+            continue
+
+        try:
+            with open(meta_path, "r") as meta_file:
+                module = json.load(meta_file)
+            if not isinstance(module, dict):
+                invalid_modules.append({
+                    "moddir": moddir,
+                    "reason": "invalid .iiab-meta"
+                })
+                continue
+            module["moddir"] = module.get("moddir", moddir)
+            module["source"] = "iiab-meta"
+            modules.append(module)
+        except:
+            invalid_modules.append({
+                "moddir": moddir,
+                "reason": "invalid .iiab-meta"
+            })
+
+    return modules, invalid_modules
 
 def get_external_device_info(cmd_info):
     extdev_info = {}

--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -1238,6 +1238,25 @@ def validate_sync_source_host(source_host):
 
     return None
 
+def validate_sync_content_inventory(inventory):
+    if not isinstance(inventory, dict):
+        return False
+
+    required_keys = {
+        "schema_version": int,
+        "server": dict,
+        "zims": list,
+        "modules": list
+    }
+
+    for key, expected_type in required_keys.items():
+        if key not in inventory:
+            return False
+        if not isinstance(inventory[key], expected_type):
+            return False
+
+    return True
+
 def get_sync_content(cmd_info):
     try:
         source_host = cmd_info['cmd_args']['source_host']
@@ -1268,6 +1287,9 @@ def get_sync_content(cmd_info):
         inventory = json.loads(inventory_bytes.decode('utf-8'))
     except:
         return cmd_error(cmd=cmd_info['cmd'], msg='Invalid sync content inventory JSON')
+
+    if not validate_sync_content_inventory(inventory):
+        return cmd_error(cmd=cmd_info['cmd'], msg='Invalid sync content inventory format')
 
     return json.dumps(inventory)
 

--- a/roles/cmdsrv/files/iiab-sync.service
+++ b/roles/cmdsrv/files/iiab-sync.service
@@ -1,0 +1,10 @@
+<?xml version="1.0" standalone="no"?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<service-group>
+  <name replace-wildcards="yes">IIAB Sync Server on %h</name>
+  <service>
+    <type>_iiab-sync._tcp</type>
+    <port>80</port>
+    <txt-record>path=/common/assets/iiab-sync/content.json</txt-record>
+  </service>
+</service-group>

--- a/roles/cmdsrv/files/iiab-sync.service
+++ b/roles/cmdsrv/files/iiab-sync.service
@@ -6,5 +6,6 @@
     <type>_iiab-sync._tcp</type>
     <port>80</port>
     <txt-record>path=/common/assets/iiab-sync/content.json</txt-record>
+    <txt-record>ssh_user=iiab-admin</txt-record>
   </service>
 </service-group>

--- a/roles/cmdsrv/tasks/main.yml
+++ b/roles/cmdsrv/tasks/main.yml
@@ -12,6 +12,8 @@
     - python3-nacl
     - python3-bs4
     - python3-lxml
+    - avahi-daemon
+    - avahi-utils
     - uuid
     - aria2
   tags:
@@ -103,6 +105,27 @@
         mode=0700
         owner=root
         group=root
+
+- name: Create Avahi services directory
+  file: path=/etc/avahi/services
+        mode=0755
+        owner=root
+        group=root
+        state=directory
+
+- name: Install IIAB sync Avahi service
+  copy: src=iiab-sync.service
+        dest=/etc/avahi/services/iiab-sync.service
+        mode=0644
+        owner=root
+        group=root
+
+- name: Enable and restart Avahi daemon
+  systemd:
+    name: avahi-daemon
+    state: restarted
+    enabled: true
+  when: is_debuntu
 
 - name: Set permissions on sqlite db
   file: dest="{{ cmdsrv_dir }}/{{cmdsrv_dbname }}"

--- a/roles/console/files/htmlf/40-install_content.html
+++ b/roles/console/files/htmlf/40-install_content.html
@@ -315,6 +315,15 @@
                     </div>
                   </div>
                   <p></p>
+                  <div class="row">
+                    <div class="col-sm-3">
+                      <button id="DISCOVER-SYNC-SERVERS" type="button" class="btn btn-lg btn-primary">Discover Servers</button>
+                    </div>
+                    <div class="col-sm-9">
+                      <div id="syncServersList"> </div>
+                    </div>
+                  </div>
+                  <p></p>
                   <div id="syncContentStatus"> </div>
                   <div class="row">
                     <div class="col-sm-12">

--- a/roles/console/files/htmlf/40-install_content.html
+++ b/roles/console/files/htmlf/40-install_content.html
@@ -299,12 +299,19 @@
                 </div>
                 <div id="instManageContentSync" class="tab-pane">
                   <div class="row">
-                    <div class="col-sm-5">
+                    <div class="col-sm-4">
                       <label for="syncSourceHost">Source Server</label>
                       <input id="syncSourceHost" type="text" class="form-control" placeholder="192.168.1.118">
                     </div>
                     <div class="col-sm-3">
+                      <label for="syncSourceUser">Source SSH User (optional)</label>
+                      <input id="syncSourceUser" type="text" class="form-control" placeholder="garba">
+                    </div>
+                    <div class="col-sm-3">
                       <button id="LOAD-SYNC-CONTENT" type="button" class="btn btn-lg btn-primary">Load Content</button>
+                    </div>
+                    <div class="col-sm-2">
+                      <button id="SYNC-SELECTED-CONTENT" type="button" class="btn btn-lg btn-primary">Sync Selected</button>
                     </div>
                   </div>
                   <p></p>

--- a/roles/console/files/htmlf/40-install_content.html
+++ b/roles/console/files/htmlf/40-install_content.html
@@ -242,6 +242,8 @@
                     call-after="setCopyContentButtonText">Installed Content </a></li>
                 <li class="nav-item"><a id="instManageContentUsbTab" href="#instManageContentUsb" class="nav-link small"
                     call-after="setCopyContentButtonText">Content on USB</a></li>
+                <li class="nav-item"><a id="instManageContentSyncTab" href="#instManageContentSync" class="nav-link small"
+                    call-after="setCopyContentButtonText">Content on Server</a></li>
               </ul>
             </div>
           </div>
@@ -292,6 +294,31 @@
                     <div class="col-sm-12">
                       <h3>Available OER2Go(RACHEL) Modules: </h3>
                       <div id="externalOer2goModules"> </div>
+                    </div>
+                  </div>
+                </div>
+                <div id="instManageContentSync" class="tab-pane">
+                  <div class="row">
+                    <div class="col-sm-5">
+                      <label for="syncSourceHost">Source Server</label>
+                      <input id="syncSourceHost" type="text" class="form-control" placeholder="192.168.1.118">
+                    </div>
+                    <div class="col-sm-3">
+                      <button id="LOAD-SYNC-CONTENT" type="button" class="btn btn-lg btn-primary">Load Content</button>
+                    </div>
+                  </div>
+                  <p></p>
+                  <div id="syncContentStatus"> </div>
+                  <div class="row">
+                    <div class="col-sm-12">
+                      <h3>Available ZIM Files: </h3>
+                      <div id="syncZimModules"> </div>
+                    </div>
+                  </div>
+                  <div class="row">
+                    <div class="col-sm-12">
+                      <h3>Available OER2Go(RACHEL) Modules: </h3>
+                      <div id="syncOer2goModules"> </div>
                     </div>
                   </div>
                 </div>

--- a/roles/console/files/htmlf/40-install_content.html
+++ b/roles/console/files/htmlf/40-install_content.html
@@ -304,8 +304,8 @@
                       <input id="syncSourceHost" type="text" class="form-control" placeholder="192.168.1.118">
                     </div>
                     <div class="col-sm-3">
-                      <label for="syncSourceUser">Source SSH User (optional)</label>
-                      <input id="syncSourceUser" type="text" class="form-control" placeholder="garba">
+                      <label for="syncSourceUser">Source SSH User</label>
+                      <input id="syncSourceUser" type="text" class="form-control" placeholder="iiab-admin">
                     </div>
                     <div class="col-sm-3">
                       <button id="LOAD-SYNC-CONTENT" type="button" class="btn btn-lg btn-primary">Load Content</button>

--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -43,6 +43,7 @@ var zimsUpgradeable = {}; // list of permarefs of zims that can be upgraded with
 var zimsDownloading = []; // list of ids of zims being downloaded
 var zimsCopying = []; // list of zims being copied
 var zimsExternal = []; // list of zims on external device
+var syncContentInventory = {}; // content inventory loaded from another IIAB server
 var oer2goInstalled = []; // list of Oer2go items already installed
 var oer2goWip = {}; // list of copying, downloading, exporting
 var oer2goDownloading = []; // list of Oer2go items being downloaded
@@ -507,8 +508,12 @@ function instContentButtonsEvents() {
     make_button_disabled("#REMOVE-CONTENT", false);
   });
 
-    $("#FIND-USB").click(function(){
+  $("#FIND-USB").click(function(){
     refreshExternalList();
+  });
+
+  $("#LOAD-SYNC-CONTENT").click(function(){
+    loadSyncContent();
   });
 
   $("#COPY-CONTENT").click(function(){

--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -516,6 +516,10 @@ function instContentButtonsEvents() {
     loadSyncContent();
   });
 
+  $("#SYNC-SELECTED-CONTENT").click(function(){
+    syncSelectedContent();
+  });
+
   $("#COPY-CONTENT").click(function(){
   	// assume that we can only get here if there are both internal and external devices
   	make_button_disabled("#COPY-CONTENT", true);

--- a/roles/console/files/js/admin_console.js
+++ b/roles/console/files/js/admin_console.js
@@ -516,6 +516,10 @@ function instContentButtonsEvents() {
     loadSyncContent();
   });
 
+  $("#DISCOVER-SYNC-SERVERS").click(function(){
+    discoverSyncServers();
+  });
+
   $("#SYNC-SELECTED-CONTENT").click(function(){
     syncSelectedContent();
   });

--- a/roles/console/files/js/content_functions.js
+++ b/roles/console/files/js/content_functions.js
@@ -541,6 +541,19 @@ function loadSyncContent(){
 }
 
 function procSyncContent(data){
+  if (!data || typeof data !== "object"){
+    syncContentInventory = {};
+    $("#syncContentStatus").html("Error: invalid response from source server.");
+    return;
+  }
+
+  if (!data.server || typeof data.server !== "object")
+    data.server = {};
+  if (!Array.isArray(data.zims))
+    data.zims = [];
+  if (!Array.isArray(data.modules))
+    data.modules = [];
+
   syncContentInventory = data;
 
   var sourceName = syncContentInventory.server.hostname || $("#syncSourceHost").val().trim();
@@ -565,17 +578,23 @@ function renderSyncZimList(){
 
   zims.forEach(function(zim){
     var zimId = zim.id || zim.file_ref || zim.path;
+    var fileRef = getSyncZimFileRef(zim);
     var title = zim.title || zimId;
     var lang = zim.language || "";
     var size = zim.size_k ? readableSize(zim.size_k) : "";
     var details = [];
+
+    if (!fileRef)
+      return;
 
     if (lang != "")
       details.push(lang);
     if (size != "")
       details.push(size);
 
-    html += '<label><input type="checkbox" name="' + escapeSyncHtml(zimId) + '"></label>';
+    html += '<label><input type="checkbox" class="sync-zim-checkbox" name="' + escapeSyncHtml(zimId) + '"';
+    html += ' data-zim-id="' + escapeSyncHtml(zimId) + '"';
+    html += ' data-file-ref="' + escapeSyncHtml(fileRef) + '"></label>';
     html += '<span class="zim-desc">&nbsp;&nbsp;' + escapeSyncHtml(title);
     if (details.length > 0)
       html += ' (' + escapeSyncHtml(details.join(", ")) + ')';
@@ -604,7 +623,11 @@ function renderSyncOer2goModules(){
     var description = mod.description || "";
     var size = mod.ksize ? readableSize(mod.ksize) : "";
 
-    html += '<label><input type="checkbox" name="' + escapeSyncHtml(moddir) + '"></label>';
+    if (!moddir)
+      return;
+
+    html += '<label><input type="checkbox" class="sync-module-checkbox" name="' + escapeSyncHtml(moddir) + '"';
+    html += ' data-moddir="' + escapeSyncHtml(moddir) + '"></label>';
     html += '<span class="zim-desc">&nbsp;&nbsp;' + escapeSyncHtml(title);
     if (description != "")
       html += ': ' + escapeSyncHtml(description);
@@ -615,6 +638,92 @@ function renderSyncOer2goModules(){
   });
 
   $("#syncOer2goModules").html(html);
+}
+
+function getSyncZimFileRef(zim){
+  if (zim.file_ref)
+    return zim.file_ref;
+
+  if (zim.path){
+    var pathParts = zim.path.split("/");
+    var zimFile = pathParts[pathParts.length - 1];
+    return zimFile.split(".zim")[0];
+  }
+
+  return null;
+}
+
+function getSyncCommandArgs(){
+  var sourceHost = $("#syncSourceHost").val().trim();
+  var sourceUser = $("#syncSourceUser").val().trim();
+  var cmdArgs = {"source_host": sourceHost};
+
+  if (sourceUser != "")
+    cmdArgs["source_user"] = sourceUser;
+
+  return cmdArgs;
+}
+
+function getSelectedSyncZims(){
+  var zims = [];
+
+  $("#syncZimModules input.sync-zim-checkbox:checked").each(function(){
+    zims.push({
+      "zim_id": $(this).data("zim-id"),
+      "file_ref": $(this).data("file-ref")
+    });
+  });
+
+  return zims;
+}
+
+function getSelectedSyncModules(){
+  var modules = [];
+
+  $("#syncOer2goModules input.sync-module-checkbox:checked").each(function(){
+    modules.push({
+      "moddir": $(this).data("moddir")
+    });
+  });
+
+  return modules;
+}
+
+function syncSelectedContent(){
+  var baseArgs = getSyncCommandArgs();
+  var zims = getSelectedSyncZims();
+  var modules = getSelectedSyncModules();
+  var totalCount = zims.length + modules.length;
+
+  if (baseArgs.source_host == ""){
+    alert("Please enter a source server IP or hostname.");
+    return;
+  }
+
+  if (totalCount == 0){
+    alert("Please select at least one item to sync.");
+    return;
+  }
+
+  if (!confirm("Schedule " + totalCount + " selected item(s) to sync from " + baseArgs.source_host + "?"))
+    return;
+
+  zims.forEach(function(zim){
+    var cmdArgs = Object.assign({}, baseArgs);
+    cmdArgs["zim_id"] = zim.zim_id;
+    cmdArgs["file_ref"] = zim.file_ref;
+    sendCmdSrvCmd("SYNC-ZIMS " + JSON.stringify(cmdArgs), genericCmdHandler);
+  });
+
+  modules.forEach(function(mod){
+    var cmdArgs = Object.assign({}, baseArgs);
+    cmdArgs["moddir"] = mod.moddir;
+    sendCmdSrvCmd("SYNC-OER2GO-MOD " + JSON.stringify(cmdArgs), genericCmdHandler);
+  });
+
+  $("#syncZimModules input.sync-zim-checkbox").prop("checked", false);
+  $("#syncOer2goModules input.sync-module-checkbox").prop("checked", false);
+  $("#syncContentStatus").html("Selected content scheduled to sync. Please view Utilities-&gt;Display Job Status to see the results.");
 }
 
 function escapeSyncHtml(value){

--- a/roles/console/files/js/content_functions.js
+++ b/roles/console/files/js/content_functions.js
@@ -522,6 +522,113 @@ function renderExternalList() {
   }
 }
 
+function loadSyncContent(){
+  var sourceHost = $("#syncSourceHost").val().trim();
+
+  if (sourceHost == ""){
+    alert("Please enter a source server IP or hostname.");
+    return;
+  }
+
+  var cmdArgs = {"source_host": sourceHost};
+  var cmd = "GET-SYNC-CONTENT " + JSON.stringify(cmdArgs);
+
+  $("#syncContentStatus").html("Loading content from " + sourceHost + "...");
+  $("#syncZimModules").html("");
+  $("#syncOer2goModules").html("");
+
+  return sendCmdSrvCmd(cmd, procSyncContent, "LOAD-SYNC-CONTENT");
+}
+
+function procSyncContent(data){
+  syncContentInventory = data;
+
+  var sourceName = syncContentInventory.server.hostname || $("#syncSourceHost").val().trim();
+  $("#syncContentStatus").html("Loaded content from " + escapeSyncHtml(sourceName) + ".");
+
+  renderSyncZimList();
+  renderSyncOer2goModules();
+}
+
+function renderSyncZimList(){
+  var html = "";
+  var zims = syncContentInventory.zims || [];
+
+  if (zims.length == 0){
+    $("#syncZimModules").html("No ZIM files found.");
+    return;
+  }
+
+  zims.sort(function(a, b){
+    return (a.title || a.id).localeCompare(b.title || b.id);
+  });
+
+  zims.forEach(function(zim){
+    var zimId = zim.id || zim.file_ref || zim.path;
+    var title = zim.title || zimId;
+    var lang = zim.language || "";
+    var size = zim.size_k ? readableSize(zim.size_k) : "";
+    var details = [];
+
+    if (lang != "")
+      details.push(lang);
+    if (size != "")
+      details.push(size);
+
+    html += '<label><input type="checkbox" name="' + escapeSyncHtml(zimId) + '"></label>';
+    html += '<span class="zim-desc">&nbsp;&nbsp;' + escapeSyncHtml(title);
+    if (details.length > 0)
+      html += ' (' + escapeSyncHtml(details.join(", ")) + ')';
+    html += '</span><BR>';
+  });
+
+  $("#syncZimModules").html(html);
+}
+
+function renderSyncOer2goModules(){
+  var html = "";
+  var modules = syncContentInventory.modules || [];
+
+  if (modules.length == 0){
+    $("#syncOer2goModules").html("No OER2Go(RACHEL) modules found.");
+    return;
+  }
+
+  modules.sort(function(a, b){
+    return (a.title || a.moddir).localeCompare(b.title || b.moddir);
+  });
+
+  modules.forEach(function(mod){
+    var moddir = mod.moddir || mod.menu_item_name;
+    var title = mod.title || moddir;
+    var description = mod.description || "";
+    var size = mod.ksize ? readableSize(mod.ksize) : "";
+
+    html += '<label><input type="checkbox" name="' + escapeSyncHtml(moddir) + '"></label>';
+    html += '<span class="zim-desc">&nbsp;&nbsp;' + escapeSyncHtml(title);
+    if (description != "")
+      html += ': ' + escapeSyncHtml(description);
+    html += '</span>';
+    if (size != "")
+      html += '<span style="display:inline-block; width:120px;"> Size: ' + escapeSyncHtml(size) + '</span>';
+    html += '<BR>';
+  });
+
+  $("#syncOer2goModules").html(html);
+}
+
+function escapeSyncHtml(value){
+  return String(value).replace(/[&<>"']/g, function(char) {
+    return {
+      '&': '&amp;',
+      '<': '&lt;',
+      '>': '&gt;',
+      '"': '&quot;',
+      "'": '&#39;'
+    }[char];
+  });
+}
+
 function delDownloadedFileList(id, sub_dir) {
   var delArgs = {}
 	var fileList = [];

--- a/roles/console/files/js/content_functions.js
+++ b/roles/console/files/js/content_functions.js
@@ -237,6 +237,22 @@ function installPreset(presetId){
 function manageContentInit(){
 	refreshAllInstalledList();
 	refreshExternalList();
+  initSyncSourceUser();
+}
+
+function initSyncSourceUser(){
+  var sourceUser = "iiab-admin";
+
+  try {
+    sourceUser = localStorage.getItem("iiabSyncSourceUser") || sourceUser;
+  } catch(e) {}
+
+  $("#syncSourceUser").val(sourceUser);
+  $("#syncSourceUser").change(function(){
+    try {
+      localStorage.setItem("iiabSyncSourceUser", $(this).val().trim());
+    } catch(e) {}
+  });
 }
 
 function getExternalDevInfo(){
@@ -565,12 +581,14 @@ function procSyncServers(data){
     var address = server.address || "";
     var host = server.host || address;
     var serviceName = server.service_name || host;
+    var sshUser = server.ssh_user || "";
 
     if (address == "")
       return;
 
     html += '<label><input type="radio" class="sync-server-radio" name="sync-server"';
-    html += ' data-address="' + escapeSyncHtml(address) + '">';
+    html += ' data-address="' + escapeSyncHtml(address) + '"';
+    html += ' data-ssh-user="' + escapeSyncHtml(sshUser) + '">';
     html += '&nbsp;&nbsp;' + escapeSyncHtml(serviceName) + ' (' + escapeSyncHtml(address) + ')';
     html += '</label><BR>';
   });
@@ -578,6 +596,8 @@ function procSyncServers(data){
   $("#syncServersList").html(html);
   $("#syncServersList input.sync-server-radio").change(function(){
     $("#syncSourceHost").val($(this).data("address"));
+    if ($(this).data("ssh-user"))
+      $("#syncSourceUser").val($(this).data("ssh-user"));
   });
 }
 
@@ -699,8 +719,12 @@ function getSyncCommandArgs(){
   var sourceUser = $("#syncSourceUser").val().trim();
   var cmdArgs = {"source_host": sourceHost};
 
-  if (sourceUser != "")
+  if (sourceUser != ""){
     cmdArgs["source_user"] = sourceUser;
+    try {
+      localStorage.setItem("iiabSyncSourceUser", sourceUser);
+    } catch(e) {}
+  }
 
   return cmdArgs;
 }

--- a/roles/console/files/js/content_functions.js
+++ b/roles/console/files/js/content_functions.js
@@ -540,6 +540,47 @@ function loadSyncContent(){
   return sendCmdSrvCmd(cmd, procSyncContent, "LOAD-SYNC-CONTENT");
 }
 
+function discoverSyncServers(){
+  $("#syncServersList").html("Discovering IIAB servers...");
+  return sendCmdSrvCmd("GET-SYNC-SERVERS", procSyncServers, "DISCOVER-SYNC-SERVERS");
+}
+
+function procSyncServers(data){
+  var servers = [];
+  var html = "";
+
+  if (data && Array.isArray(data.servers))
+    servers = data.servers;
+
+  if (servers.length == 0){
+    $("#syncServersList").html("No sync servers discovered. Enter a source server manually.");
+    return;
+  }
+
+  servers.sort(function(a, b){
+    return (a.host || a.address).localeCompare(b.host || b.address);
+  });
+
+  servers.forEach(function(server){
+    var address = server.address || "";
+    var host = server.host || address;
+    var serviceName = server.service_name || host;
+
+    if (address == "")
+      return;
+
+    html += '<label><input type="radio" class="sync-server-radio" name="sync-server"';
+    html += ' data-address="' + escapeSyncHtml(address) + '">';
+    html += '&nbsp;&nbsp;' + escapeSyncHtml(serviceName) + ' (' + escapeSyncHtml(address) + ')';
+    html += '</label><BR>';
+  });
+
+  $("#syncServersList").html(html);
+  $("#syncServersList input.sync-server-radio").change(function(){
+    $("#syncSourceHost").val($(this).data("address"));
+  });
+}
+
 function procSyncContent(data){
   if (!data || typeof data !== "object"){
     syncContentInventory = {};

--- a/test-files/sync-content.json
+++ b/test-files/sync-content.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": 1,
+  "server": {
+    "hostname": "iiab-source",
+    "role": "source",
+    "base_url": "http://<source-ip>",
+    "generated_by": "manual-inventory-test"
+  },
+  "zims": [
+    {
+      "id": "test-zim",
+      "title": "Test ZIM",
+      "file_ref": "test",
+      "path": "/library/zims/content/test.zim",
+      "size_k": 1024,
+      "language": "eng"
+    }
+  ],
+  "modules": [
+    {
+      "moddir": "en-test-module",
+      "title": "English Test Module",
+      "description": "Small static module used for sync testing.",
+      "lang": "en",
+      "ksize": 1024,
+      "menu_item_name": "en-test-module",
+      "intended_use": "html",
+      "source": "iiab-meta"
+    }
+  ]
+}


### PR DESCRIPTION

This PR adds an initial Sync Server Content workflow to Admin Console. It allows
one IIAB server to discover another IIAB server, load its ZIM/module inventory,
and pull selected content on demand.

Implemented:

- Avahi `_iiab-sync._tcp` advertisement
- `GET-SYNC-SERVERS`
- `MAKE-SYNC-CONTENT`
- `GET-SYNC-CONTENT`
- `SYNC-ZIMS`
- `SYNC-OER2GO-MOD`
- Manage Content UI for remote content
- `.iiab-meta` support for custom static modules
- pull-only rsync transfer from destination to source

Out of scope for this PR:

- Calibre Web/database-backed content
- automated sync
- push sync
- nmap fallback
- syncing arbitrary applications

