### PR TITLE
Replace deprecated Ansible syntax

### DIFF
--- a/roles/cmdsrv/tasks/main.yml
+++ b/roles/cmdsrv/tasks/main.yml
@@ -2,9 +2,10 @@
 #  include: packages.yml
 
 - name: Install packages for cmdsrv on python 3
-  package: name={{ item }}
-           state=present
-  with_items:
+  package:
+    name: "{{ item }}"
+    state: present
+  loop:
     - python3-systemd
     - python3-zmq
     - python3-yaml
@@ -49,7 +50,7 @@
     section: wasabi-iiab-share
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
-  with_items:
+  loop:
     - option: type
       value: s3
     - option: provider
@@ -73,7 +74,7 @@
     section: contabo
     option: "{{ item.option }}"
     value: "{{ item.value | string }}"
-  with_items:
+  loop:
     - option: type
       value: s3
     - option: provider
@@ -86,60 +87,66 @@
       value: 2045d93fc26405d48ac409cb78bd0133
 
 - name: Create cmdsrv directory
-  file: path={{ item }}
-        mode=0700
-        owner=root
-        group=root
-        state=directory
-  with_items:
+  file:
+    path: "{{ item }}"
+    mode: '0700'
+    owner: root
+    group: root
+    state: directory
+  loop:
     - "{{ cmdsrv_dir }}"
     - "{{ cmdsrv_dir }}/scripts"
     - "{{ cmdsrv_dir }}/assets"
     - "{{ cmdsrv_dir }}/presets"
 
 - name: Install Command Server Executable
-  copy: src=iiab-cmdsrv3.py
-        dest="{{ cmdsrv_dir }}/iiab-cmdsrv3.py"
-        mode=0700
-        owner=root
-        group=root
+  copy:
+    src: iiab-cmdsrv3.py
+    dest: "{{ cmdsrv_dir }}/iiab-cmdsrv3.py"
+    mode: '0700'
+    owner: root
+    group: root
 
 - name: Set permissions on sqlite db
-  file: dest="{{ cmdsrv_dir }}/{{cmdsrv_dbname }}"
-        mode=0600
-        owner=root
-        group=root
-        state=touch
+  file:
+    dest: "{{ cmdsrv_dir }}/{{cmdsrv_dbname }}"
+    mode: '0600'
+    owner: root
+    group: root
+    state: touch
 
 - name: Copy scripts
-  copy: src={{ item }}
-            dest="{{ cmdsrv_dir }}/scripts"
-            mode=0755
-            owner=root
-            group=root
+  copy:
+    src: "{{ item }}"
+    dest: "{{ cmdsrv_dir }}/scripts"
+    mode: '0755'
+    owner: root
+    group: root
   with_fileglob:
             - scripts/*
 
 - name: Copy templated scripts
-  template: src={{ item }}
-            dest="{{ cmdsrv_dir }}/scripts"
-            mode=0755
-            owner=root
-            group=root
-  with_items:
+  template:
+    src: "{{ item }}"
+    dest: "{{ cmdsrv_dir }}/scripts"
+    mode: '0755'
+    owner: root
+    group: root
+  loop:
             # scripts/get_kiwix_catalog
             - scripts/constants.sh
             - scripts/install_menu_defs.py
             - scripts/sync_menu_defs.py
 
 - name: Copy and rename templated scripts
-  template: backup=yes
-            src={{ item.src }}
-            dest={{ item.dest }}
-            owner=root
-            group=root
-            mode=0755
-  with_items:
+  template:
+    backup: true
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: root
+    mode: '0755'
+  loop:
     #- { src: 'scripts/get_kiwix_catalog_libxml.py', dest: '{{ cmdsrv_dir }}/scripts/get_kiwix_catalog'}
     # - { src: 'scripts/get_kiwix_catalog_rootxml.py', dest: '{{ cmdsrv_dir }}/scripts/get_kiwix_catalog'}
     - { src: 'scripts/get_kiwix_catalog_opds_v2.py', dest: '{{ cmdsrv_dir }}/scripts/get_kiwix_catalog'}
@@ -149,21 +156,23 @@
     - { src: 'scripts/upgrade-zims.py', dest: '{{ cmdsrv_dir }}/scripts/upgrade-zims.py'}
 
 - name: Copy templated assets
-  template: src={{ item }}
-            dest="{{ cmdsrv_dir }}/assets"
-            mode=0755
-            owner=root
-            group=root
-  with_items:
+  template:
+    src: "{{ item }}"
+    dest: "{{ cmdsrv_dir }}/assets"
+    mode: '0755'
+    owner: root
+    group: root
+  loop:
             - assets/run-roles-base.yml
             - assets/adm_ansible_vars.yml
 
 - name: Copy presets recursively
-  copy: src=presets
-            dest="{{ cmdsrv_dir }}"
-            mode=0755
-            owner=root
-            group=root
+  copy:
+    src: presets
+    dest: "{{ cmdsrv_dir }}"
+    mode: '0755'
+    owner: root
+    group: root
 
 #- name: Allow running iiab_update_menus from the command line
 #  file: src="{{ cmdsrv_dir }}/scripts/iiab_update_menus.py"
@@ -171,12 +180,13 @@
 #        state=link
 
 - name: Copy templated utilies
-  template: src={{ item }}
-            dest="/usr/bin/"
-            mode=0755
-            owner=root
-            group=root
-  with_items:
+  template:
+    src: "{{ item }}"
+    dest: "/usr/bin/"
+    mode: '0755'
+    owner: root
+    group: root
+  loop:
             - utilities/iiab-get-kiwix-cat
             - utilities/iiab-get-oer2go-cat
             - utilities/iiab-install-oer2go-mod
@@ -186,12 +196,13 @@
             - utilities/mk-preset.py
 
 - name: Copy default kiwix_catalog.json
-  copy: src="json/kiwix_catalog.json"
-        dest="/etc/iiab/kiwix_catalog.json"
-        mode=0644
-        force=no
-        owner=root
-        group=root
+  copy:
+    src: "json/kiwix_catalog.json"
+    dest: "/etc/iiab/kiwix_catalog.json"
+    mode: '0644'
+    force: false
+    owner: root
+    group: root
 
 #- name: Create fresh kiwix_catalog.json
 #  shell: "iiab-get-kiwix-cat -v"
@@ -200,58 +211,64 @@
 #- debug: var=kiwix_cat.stdout_lines
 
 - name: Copy default oer2go_catalog.json
-  copy: src="json/oer2go_catalog.json"
-        dest="/etc/iiab/oer2go_catalog.json"
-        mode=0644
-        force=yes
-        owner=root
-        group=root
+  copy:
+    src: "json/oer2go_catalog.json"
+    dest: "/etc/iiab/oer2go_catalog.json"
+    mode: '0644'
+    force: true
+    owner: root
+    group: root
 
 #- name: Create fresh oer2go_catalog.json
 #  shell: "iiab-get-oer2go-cat"
 #  register: oer2go_cat
 
 - name: Create symlink from /common/assets to kiwix_catalog.json
-  file: src=/etc/iiab/kiwix_catalog.json
-        dest={{ doc_root }}/common/assets/kiwix_catalog.json
-        owner=root
-        group=root
-        state=link
+  file:
+    src: /etc/iiab/kiwix_catalog.json
+    dest: "{{ doc_root }}/common/assets/kiwix_catalog.json"
+    owner: root
+    group: root
+    state: link
 
 - name: Create symlink from /common/assets to oer2go_catalog.json
-  file: src=/etc/iiab/oer2go_catalog.json
-        dest={{ doc_root }}/common/assets/oer2go_catalog.json
-        owner=root
-        group=root
-        state=link
+  file:
+    src: /etc/iiab/oer2go_catalog.json
+    dest: "{{ doc_root }}/common/assets/oer2go_catalog.json"
+    owner: root
+    group: root
+    state: link
 
 - name: Create cmdsrv.conf file
-  template: backup=yes
-            src=cmdsrv.conf.j2
-            dest="{{ cmdsrv_dir }}/cmdsrv.conf"
-            owner=root
-            group=root
-            mode=0644
+  template:
+    backup: true
+    src: cmdsrv.conf.j2
+    dest: "{{ cmdsrv_dir }}/cmdsrv.conf"
+    owner: root
+    group: root
+    mode: '0644'
 
 # Create iiab-cmdsrv service
 
 - name: Create iiab-cmdsrv service
-  template: backup=yes
-            src={{ item.src }}
-            dest={{ item.dest }}
-            owner=root
-            group=root
-            mode={{ item.mode }}
-  with_items:
+  template:
+    backup: true
+    src: "{{ item.src }}"
+    dest: "{{ item.dest }}"
+    owner: root
+    group: root
+    mode: "{{ item.mode }}"
+  loop:
     - { src: 'iiab-cmdsrv.service.j2', dest: '/etc/systemd/system/iiab-cmdsrv.service', mode: '0644'}
     - { src: 'iiab-cmdsrv-ctl.j2', dest: '/usr/bin/iiab-cmdsrv-ctl', mode: '0755'}
 
 - name: Create ansible.cfg # stop logging ansible runs to /opt/iiab/iiab/iiab-install.log
-  template: src=ansible.cfg.j2
-            dest="{{ cmdsrv_dir }}/ansible.cfg"
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: ansible.cfg.j2
+    dest: "{{ cmdsrv_dir }}/ansible.cfg"
+    owner: root
+    group: root
+    mode: '0644'
 
 - name: Ask systemd to reread the unit files, picks up changes done
   shell: systemctl daemon-reload

--- a/roles/cmdsrv/tasks/main.yml
+++ b/roles/cmdsrv/tasks/main.yml
@@ -28,7 +28,7 @@
   pip:
     name: speedtest-cli
     virtualenv: /usr/local/speedtest
-    virtualenv_site_packages: no
+    virtualenv_site_packages: false
     virtualenv_command: python3 -m venv /usr/local/speedtest
     extra_args: "--no-cache-dir"
 

--- a/roles/cmdsrv/tasks/packages.yml.unused
+++ b/roles/cmdsrv/tasks/packages.yml.unused
@@ -1,7 +1,8 @@
 - name: Install packages for cmdsrv
-  package: name={{ item }}
-           state=present
-  with_items:
+  package:
+    name: "{{ item }}"
+    state: present
+  loop:
     - apache2
     - php{{ php_version }}
     - php{{ php_version }}-mysql
@@ -17,16 +18,18 @@
   when: is_debuntu
 
 - name: Install ubuntu connector apache to php
-  package: name=libapache2-mod-php
-           state=present
+  package:
+    name: libapache2-mod-php
+    state: present
   tags:
     - download
   when: is_ubuntu
 
 - name: Install packages for cmdsrv
-  package: name={{ item }}
-           state=present
-  with_items:
+  package:
+    name: "{{ item }}"
+    state: present
+  loop:
     - httpd
     - php
     - mod_ssl
@@ -44,4 +47,3 @@
   tags:
     - download
   when: is_redhat
-

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -75,7 +75,7 @@
     dest: "{{ item.dest }}"
     owner: root
     group: root
-    mode: 0644
+    mode: '0644'
   loop:
     - { src: 'adm_const.py.j2', dest: '{{ py3_dist_path }}/iiab/adm_const.py' }
     - { src: 'adm_lib.py', dest: '{{ py3_dist_path }}/iiab/adm_lib.py' }
@@ -85,12 +85,12 @@
   get_url:
     url: "{{ iiab_download_url }}/heart-beat.txt"
     dest: /tmp/heart-beat.txt
-  ignore_errors: True
+  ignore_errors: true
   register: internet_access_test
 
 - name: Set internet_available if download succeeded and not disregard_network
   set_fact:
-    internet_available: True
+    internet_available: true
   when: not internet_access_test.failed
 
 - name: Remove downloaded Internet test file /tmp/heart-beat.txt
@@ -112,8 +112,8 @@
     dest: "{{ doc_root }}/common/assets/vector-map-idx.json"
     owner: root
     group: root
-    mode: 0644
-    force: yes
+    mode: '0644'
+    force: true
   when: not osm_vector_maps_enabled
 
 # Put dummy idx file in place only if it does not already exist and until calculated in js-menu if osm_vector_maps is enabled
@@ -123,8 +123,8 @@
     dest: "{{ doc_root }}/common/assets/vector-map-idx.json"
     owner: root
     group: root
-    mode: 0644
-    force: no
+    mode: '0644'
+    force: false
   when: osm_vector_maps_enabled
 
 # Copy Map Catalog used by Admin Console
@@ -134,6 +134,6 @@
     dest: "{{ doc_root }}/common/assets/{{ adm_maps_catalog_file }}"
     owner: root
     group: root
-    mode: 0644
-    force: yes
+    mode: '0644'
+    force: true
   # when: osm_vector_maps_enabled - always install so cmdsrv has it

--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -22,7 +22,7 @@
     # group: root
     # mode: '0755'
     state: directory
-  with_items:
+  loop:
     #- "{{ content_base }}/downloads"    # /library/downloads auto-created just below
     - "{{ content_base }}/downloads/zims"
     - "{{ content_base }}/downloads/maps"
@@ -50,7 +50,7 @@
     group: "{{ apache_user }}"
     mode: '0755'
     state: directory
-  with_items:
+  loop:
     - "{{ content_base }}/working/uploads"
 
 - name: File Layout - Symlink {{ doc_root }}/common/webfonts -> {{ doc_root }}/common/fonts
@@ -60,12 +60,13 @@
     state: link
 
 - name: Create admin directory
-  file: path={{ item }}
-        mode=0755
-        owner=root
-        group=root
-        state=directory
-  with_items:
+  file:
+    path: "{{ item }}"
+    mode: '0755'
+    owner: root
+    group: root
+    state: directory
+  loop:
     - "{{ admin_install_base }}"
 
 - name: Install admin lib files
@@ -75,7 +76,7 @@
     owner: root
     group: root
     mode: 0644
-  with_items:
+  loop:
     - { src: 'adm_const.py.j2', dest: '{{ py3_dist_path }}/iiab/adm_const.py' }
     - { src: 'adm_lib.py', dest: '{{ py3_dist_path }}/iiab/adm_lib.py' }
 

--- a/roles/console/tasks/main.yml
+++ b/roles/console/tasks/main.yml
@@ -1,10 +1,11 @@
 - name: Create admin-console directory tree
-  file: path={{ item }}
-        mode=0755
-        owner=root
-        group=root
-        state=directory
-  with_items:
+  file:
+    path: "{{ item }}"
+    mode: '0755'
+    owner: root
+    group: root
+    state: directory
+  loop:
     - "{{ admin_console_dir }}"
     - "{{ admin_console_dir }}/css"
     - "{{ admin_console_dir }}/help"
@@ -13,84 +14,93 @@
     - "{{ admin_console_dir }}/map"
 
 - name: Copy admin-console css files
-  copy: src={{ item }}
-        dest="{{ admin_console_dir }}/css"
-        mode=0644
-        owner=root
-        group=root
+  copy:
+    src: "{{ item }}"
+    dest: "{{ admin_console_dir }}/css"
+    mode: '0644'
+    owner: root
+    group: root
   with_fileglob:
         - css/*.css
 
 - name: Copy admin-console help files
-  copy: src={{ item }}
-        dest="{{ admin_console_dir }}/help"
-        mode=0644
-        owner=root
-        group=root
+  copy:
+    src: "{{ item }}"
+    dest: "{{ admin_console_dir }}/help"
+    mode: '0644'
+    owner: root
+    group: root
   with_fileglob:
         - help/*
 
 - name: Copy admin-console javascript files
-  copy: src={{ item }}
-        dest="{{ admin_console_dir }}/js"
-        mode=0644
-        owner=root
-        group=root
+  copy:
+    src: "{{ item }}"
+    dest: "{{ admin_console_dir }}/js"
+    mode: '0644'
+    owner: root
+    group: root
   with_fileglob:
         - js/*
 
 - name: Copy admin-console html fragment files
-  copy: src={{ item }}
-        dest="{{ admin_console_dir }}/htmlf"
-        mode=0644
-        owner=root
-        group=root
+  copy:
+    src: "{{ item }}"
+    dest: "{{ admin_console_dir }}/htmlf"
+    mode: '0644'
+    owner: root
+    group: root
   with_fileglob:
         - htmlf/*
 
 - name: Install admin-console config file for web server (now only supports nginx)
-  template: src=admin-console-nginx.conf.j2
-            dest={{ nginx_conf_dir }}/admin-console.conf
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: admin-console-nginx.conf.j2
+    dest: "{{ nginx_conf_dir }}/admin-console.conf"
+    owner: root
+    group: root
+    mode: '0644'
   when: not adm_cons_force_ssl
 
 - name: Install admin-console wsgi service
-  template: src=cmd-service3.wsgi.j2
-            dest="{{ admin_console_dir }}/cmd-service3.wsgi"
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: cmd-service3.wsgi.j2
+    dest: "{{ admin_console_dir }}/cmd-service3.wsgi"
+    owner: root
+    group: root
+    mode: '0644'
 
 - name: Put the uswgi file in place
   template:
       src: '{{ item.src}}'
       dest: '{{ item.dest }}'
-  with_items:
+  loop:
     - { src: "admin-console.ini.j2",dest: "/etc/uwsgi/apps-enabled/admin-console.ini" }
   when: nginx_enabled
 
 - name: Install admin-console server info service
-  template: src=server-info.php
-            dest="{{ admin_console_dir }}/server-info.php"
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: server-info.php
+    dest: "{{ admin_console_dir }}/server-info.php"
+    owner: root
+    group: root
+    mode: '0644'
 
 - name: Install image upload service
-  template: src=upload-image.php
-            dest="{{ admin_console_dir }}/upload-image.php"
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: upload-image.php
+    dest: "{{ admin_console_dir }}/upload-image.php"
+    owner: root
+    group: root
+    mode: '0644'
 
 - name: Install admin-console app
-  copy: src=index.html
-        dest="{{ admin_console_dir }}/index.html"
-        owner=root
-        group=root
-        mode=0644
+  copy:
+    src: index.html
+    dest: "{{ admin_console_dir }}/index.html"
+    owner: root
+    group: root
+    mode: '0644'
 
 - name: Restart nginx to pick up the config files installed
   systemd:

--- a/roles/final/tasks/main.yml
+++ b/roles/final/tasks/main.yml
@@ -1,6 +1,7 @@
 # Finish install by creating any data and restarting cmdsrv (which should not yet be running)
 
 - name: Enable and start iiab-cmdsrv service
-  service: name=iiab-cmdsrv
-           enabled=yes
-           state=restarted
+  service:
+    name: iiab-cmdsrv
+    enabled: true
+    state: restarted

--- a/roles/js-menu/tasks/main.yml
+++ b/roles/js-menu/tasks/main.yml
@@ -1,12 +1,13 @@
 # all packages and jquery/bootstrap assumed installed by iiab install
 
 - name: Create js-menu directory tree and dummy module
-  file: path={{ item }}
-        mode=0755
-        owner=root
-        group=root
-        state=directory
-  with_items:
+  file:
+    path: "{{ item }}"
+    mode: '0755'
+    owner: root
+    group: root
+    state: directory
+  loop:
     - "{{ js_menu_dir }}"
     - "{{ js_menu_dir }}menu-files"
     - "{{ js_menu_dir }}menu-files/css"
@@ -17,48 +18,53 @@
     - "{{ doc_root }}/modules/en-test_mod"
 
 - name: Copy js-menu css files
-  copy: src={{ item }}
-        dest="{{ js_menu_dir }}menu-files/css"
-        mode=0644
-        owner=root
-        group=root
+  copy:
+    src: "{{ item }}"
+    dest: "{{ js_menu_dir }}menu-files/css"
+    mode: '0644'
+    owner: root
+    group: root
   with_fileglob:
         - menu-files/css/*.css
 
 - name: Copy js-menu html files
-  copy: src={{ item }}
-        dest="{{ js_menu_dir }}menu-files/html"
-        mode=0644
-        owner=root
-        group=root
+  copy:
+    src: "{{ item }}"
+    dest: "{{ js_menu_dir }}menu-files/html"
+    mode: '0644'
+    owner: root
+    group: root
   with_fileglob:
         - menu-files/html/*
 
 - name: Copy js-menu javascript files
-  copy: src={{ item }}
-        dest="{{ js_menu_dir }}menu-files/js"
-        mode=0644
-        owner=root
-        group=root
+  copy:
+    src: "{{ item }}"
+    dest: "{{ js_menu_dir }}menu-files/js"
+    mode: '0644'
+    owner: root
+    group: root
   with_fileglob:
         - menu-files/js/*
 
 - name: Copy js-menu services files
-  copy: src={{ item }}
-        dest="{{ js_menu_dir }}menu-files/services"
-        mode=0644
-        owner=root
-        group=root
+  copy:
+    src: "{{ item }}"
+    dest: "{{ js_menu_dir }}menu-files/services"
+    mode: '0644'
+    owner: root
+    group: root
   with_fileglob:
         - menu-files/services/*
 
 - name: Copy a dummy file
-  copy: src=security/index.html
-        dest={{ item }}
-        mode=0644
-        owner=root
-        group=root
-  with_items:
+  copy:
+    src: security/index.html
+    dest: "{{ item }}"
+    mode: '0644'
+    owner: root
+    group: root
+  loop:
     - "{{ js_menu_dir }}"
     - "{{ js_menu_dir }}menu-files"
     - "{{ js_menu_dir }}menu-files/css"
@@ -67,12 +73,13 @@
     - "{{ js_menu_dir }}menu-files/services"
 
 - name: Copy a dummy module for oob menu
-  copy: src=en-test_mod/index.html
-        dest="{{ doc_root }}/modules/en-test_mod"
-        owner=root
-        group=root
-        mode=0644
-        force=no
+  copy:
+    src: en-test_mod/index.html
+    dest: "{{ doc_root }}/modules/en-test_mod"
+    owner: root
+    group: root
+    mode: '0644'
+    force: false
 
 - name: Synchronize/Copy menu-files
   synchronize:
@@ -80,26 +87,29 @@
     dest: "{{ js_menu_dir }}/sample-menus"
 
 - name: Install js-menu config file
-  template: src=config.json.j2
-            dest={{ js_menu_dir }}/config.json
-            owner=root
-            group=root
-            mode=0644
+  template:
+    src: config.json.j2
+    dest: "{{ js_menu_dir }}/config.json"
+    owner: root
+    group: root
+    mode: '0644'
 
 - name: Install index.html in home
-  copy: src=index.html
-        dest="{{ doc_root }}/home/index.html"
-        owner=root
-        group=root
-        mode=0644
+  copy:
+    src: index.html
+    dest: "{{ doc_root }}/home/index.html"
+    owner: root
+    group: root
+    mode: '0644'
 
 - name: Install menu.json in home
-  copy: src=menu.json
-        dest="{{ doc_root }}/home/menu.json"
-        owner=root
-        group=root
-        mode=0644
-        force=no
+  copy:
+    src: menu.json
+    dest: "{{ doc_root }}/home/menu.json"
+    owner: root
+    group: root
+    mode: '0644'
+    force: false
 
 - name: Does "{{ js_menu_dir }}menu-files/menu-defs" directory exist?
   stat:
@@ -115,12 +125,13 @@
   when: menu_defs_dir.stat.exists
 
 - name: Make web server user owner of images after copying
-  file: path="{{ js_menu_dir }}menu-files/images/"
-        mode=u=rwX,g=rX,o=rX
-        owner="{{ apache_user }}"
-        group="{{ apache_user }}"
-        state=directory
-        recurse=true
+  file:
+    path: "{{ js_menu_dir }}menu-files/images/"
+    mode: 'u=rwX,g=rX,o=rX'
+    owner: "{{ apache_user }}"
+    group: "{{ apache_user }}"
+    state: directory
+    recurse: true
 
 #- name: Make sure iiab-make-kiwix-lib has been run
 #  shell: "/usr/bin/iiab-make-kiwix-lib"

--- a/roles/js-menu/tasks/main.yml
+++ b/roles/js-menu/tasks/main.yml
@@ -144,7 +144,7 @@
   template:
     src: 021_www_data_set_time.j2
     dest: /etc/sudoers.d/021_www_data_set_time
-    mode: 0440
+    mode: '0440'
 
 # Now always enabled
 #- name: Remove above


### PR DESCRIPTION
Fixes items 1 and 2 of Ansible section of v1.0 tech debt (#650), also fixes other Ansible lint warnings. Item 3 (-o flag) pending discussion with Tim. Item 4 findings reported below.

### 1: Replace `with_items` with `loop`

Replaces 19 instances across role task files.

### 2: Convert inline `module: key=value` to YAML dict form

43 tasks converted to proper YAML dict form. 

### Other fixes

- Octal file modes quoted as strings (e.g. `mode: '0644'`) to prevent YAML from coercing them to integers (e.g. unquoted 0644 parses as decimal 420).
- Bare yes/no/True/False normalized to true/false

### 4: Callback warning

> [WARNING]: Callback dispatch 'v2_runner_on_skipped' failed for plugin 'default': CallbackModule.v2_runner_on_skipped() takes 2 positional arguments but 4 were given

This is not fixable in this repo - it's an ansible-core 2.20.2 internal mismatch. The dispatcher calls `default.v2_runner_on_skipped(self, result)` with 4 arguments when it only accepts 2. No callback plugin exists in our repo, we just use the default ansible-core plugin. 

We could wait for an ansible-core version upgrade or report upstream.

### Remaining lint violations (out of scope)

72 fqcn warnings (e.g. copy instead of ansible.builtin.copy). These would be a separate repo-wide change.

### Tests run

ansible-lint 26.6.0: 

- 0 `yaml[octal-values]` and `yaml[truthy]` violations
- 0 `with_items` in active task files
- 0 inline `key=value` lines

Results of `sudo ./install 2>&1 | grep -E "PLAY RECAP|ok=|failed="` :

`ok=67   unreachable=0    failed=0    skipped=4    rescued=0    ignored=0`

Tested on: Ubuntu 26.04, Python 3.14.4, nginx 1.28.3, ansible-core 2.20.2