### PR TITLE
Fix remove_wifi_connection_params_nm failing on connection names with spaces

### DIFF
--- a/roles/cmdsrv/files/iiab-cmdsrv3.py
+++ b/roles/cmdsrv/files/iiab-cmdsrv3.py
@@ -1667,7 +1667,7 @@ def remove_wifi_connection_params_nm(cmd_info):
         for devstr in dev_arr:
             props = devstr.split(':')
             if props[0] == '802-11-wireless':
-                cmdstr = 'nmcli con delete ' + props[1]
+                cmdstr = 'nmcli con delete ' + shlex.quote(props[1])
                 rc = adm.subproc_run(cmdstr)
                 if rc.returncode != 0:
                     return cmd_error(cmd=cmd, msg='Error removing Router Connection ' + props[1] + '.')


### PR DESCRIPTION
Fixes #662

remove_wifi_connection_params_nm used unquoted string concatenation, so a connection name with a space got split into multiple tokens, thus nmcli received extra unexpected arguments and the delete failed, with the function returning {"Error": "Error removing Router Connection My Test Wifi. REMOVE-WIFI-CONNECTION."}.

Fix: wrap the connection name in `shlex.quote()`. This keeps "My Test Wifi" as one argv token, and the function returns {"Success": "REMOVE-WIFI-CONNECTION ."}.

Tested on: Ubuntu 26.04, Python 3.14.4. NetworkManager isn't installed on this VM, so verified with a stand-in nmcli on PATH that mimics real argument parsing.